### PR TITLE
feat: 레이아웃페이지 추가 및 라우터 설정

### DIFF
--- a/yuquiz/src/components/postlist/SearchBar.jsx
+++ b/yuquiz/src/components/postlist/SearchBar.jsx
@@ -10,14 +10,14 @@ const SearchBar = ({ onSearch }) => {
   };
 
   return (
-    <form className="search-bar" onSubmit={handleSearch}>
+    <form className="post-search-bar" onSubmit={handleSearch}>
       <input
         type="text"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="검색어를 입력하세요..."
       />
-      <button type="submit">검색</button>
+      <button className='post-search-btn' type="submit">검색</button>
     </form>
   );
 };

--- a/yuquiz/src/components/quizlist/SearchBar.jsx
+++ b/yuquiz/src/components/quizlist/SearchBar.jsx
@@ -13,14 +13,14 @@ const SearchBar = ({ onSearch }) => {
   };
 
   return (
-    <form className="search-bar" onSubmit={handleSearch}>
+    <form className="quiz-search-bar" onSubmit={handleSearch}>
       <input
         type="text"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="검색어를 입력하세요..."
       />
-      <button type="submit">검색</button>
+      <button className='quiz-search-btn' type="submit">검색</button>
     </form>
   );
 };

--- a/yuquiz/src/components/quizlist/SubjectDropdown.jsx
+++ b/yuquiz/src/components/quizlist/SubjectDropdown.jsx
@@ -1,4 +1,3 @@
-// src/components/Navbar.jsx
 
 import React from 'react';
 import '../../styles/quiz_list_page/SubjectDropdown.scss';

--- a/yuquiz/src/components/root/ProfileCard.jsx
+++ b/yuquiz/src/components/root/ProfileCard.jsx
@@ -3,7 +3,7 @@ import '../../styles/root/ProfileCard.scss';
 
 const ProfileCard = () => {
     return (
-        <div className="profile-container">
+        <div className="root-profile-container">
             <div className="profile-picture"></div>
             <div className="profile-details">
                 <h2>원영 정</h2>

--- a/yuquiz/src/pages/login/Login.jsx
+++ b/yuquiz/src/pages/login/Login.jsx
@@ -1,8 +1,9 @@
 import "../../styles/login/Login.scss";
 import { IoMdArrowBack } from "react-icons/io";
-export default function Login() {
+
+export const Login = () => {
   return (
-    <div className="root-container">
+    <div className="login-container">
       <button className="back-button">
         <IoMdArrowBack />
       </button>

--- a/yuquiz/src/pages/mypage/EditProfile.jsx
+++ b/yuquiz/src/pages/mypage/EditProfile.jsx
@@ -8,9 +8,7 @@
 */
 
 import React, { useState } from 'react';
-import "../styles/EditProfile.scss";
-import ProfileCard from '../components/mypage/ProfileCard';
-
+import "../../styles/mypage/EditProfile.scss";
 
 const EditProfile = () => {
     const initialData = {
@@ -37,9 +35,7 @@ const EditProfile = () => {
     };
   
     return (
-        <div className='mypage-container'>
-            <ProfileCard />
-            <div className="edit-profile-container">
+        <div className="edit-profile-container">
                 <h2>내 정보 수정</h2>
                 <p>소중한 내 정보를 최신으로 관리하세요.</p>
                 <form onSubmit={handleSubmit} className="edit-profile-form">
@@ -101,7 +97,6 @@ const EditProfile = () => {
                 </div>
                 </form>
             </div>
-        </div>
     );
   }
   

--- a/yuquiz/src/pages/mypage/MyPage.jsx
+++ b/yuquiz/src/pages/mypage/MyPage.jsx
@@ -1,6 +1,5 @@
-import ListBox from "../components/mypage/ListBox";
-import ProfileCard from "../components/mypage/ProfileCard";
-import "../styles/mypage/MyPage.scss";
+import ListBox from "../../components/mypage/ListBox";
+import "../../styles/mypage/MyPage.scss";
 
 const MyPage = () => {
     // 샘플 데이터
@@ -14,22 +13,19 @@ const MyPage = () => {
   };
 
     return (
-        <div className="mypage-container">
-            <ProfileCard />
-            <div className="dashboard-container">
-                <button>홈으로</button>
-                <div className="row">
-                    <ListBox title="알림함" items={data.alerts} />
-                    <ListBox title="작성한 퀴즈 목록" items={data.quizzes} />
-                    <ListBox title="작성한 게시글 목록" items={data.posts} />
-                </div>
-                <div className="row">
-                    <ListBox title="즐겨찾기 목록" items={data.bookmarks} />
-                    <ListBox title="풀린 문제 목록" items={data.solvedProblems} />
-                    <ListBox title="좋아요 목록" items={data.favorites} />
-                </div>
-            </div>
-        </div>
+      <div className="dashboard-container">
+      <button className="my-home-btn">홈으로</button>
+      <div className="row">
+          <ListBox title="알림함" items={data.alerts} />
+          <ListBox title="작성한 퀴즈 목록" items={data.quizzes} />
+          <ListBox title="작성한 게시글 목록" items={data.posts} />
+      </div>
+      <div className="row">
+          <ListBox title="즐겨찾기 목록" items={data.bookmarks} />
+          <ListBox title="풀린 문제 목록" items={data.solvedProblems} />
+          <ListBox title="좋아요 목록" items={data.favorites} />
+      </div>
+  </div>
       );
 }
 

--- a/yuquiz/src/pages/mypage/MyPageLayout.jsx
+++ b/yuquiz/src/pages/mypage/MyPageLayout.jsx
@@ -1,0 +1,15 @@
+import ProfileCard from '../../components/mypage/ProfileCard';
+import { Outlet } from 'react-router-dom';
+import "../../styles/mypage/MyPageLayout.scss";
+
+const MyPageLayout = () => {
+  
+    return (
+        <div className='mypage-container'>
+            <ProfileCard />
+            <Outlet />
+        </div>
+    );
+  }
+  
+  export default MyPageLayout;

--- a/yuquiz/src/pages/post/PostListPage.jsx
+++ b/yuquiz/src/pages/post/PostListPage.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import SearchBar from '../components/postlist/SearchBar';
-import SubjectDropdown from '../components/postlist/SubjectDropdown';
-import PostList from '../components/postlist/PostList';
-import '../styles/post_list_page/PostListPage.scss';
+
+import '../../styles/post_list_page/PostListPage.scss';
+import SearchBar from '../../components/postlist/SearchBar';
+import SubjectDropdown from '../../components/postlist/SubjectDropdown';
+import PostList from '../../components/postlist/PostList';
 
 const PostListPage = () => {
     const postsData = [

--- a/yuquiz/src/pages/quiz/QuizCreator.jsx
+++ b/yuquiz/src/pages/quiz/QuizCreator.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { IoMdArrowBack } from "react-icons/io";
 import "../../styles/quiz/QuizCreator.scss";
 
-export default function QuizCreator() {
+export const QuizCreator = () => {
   const [questionTitle, setQuestionTitle] = useState("");
   const [questionContent, setQuestionContent] = useState("");
   const [questionType, setQuestionType] = useState("Multiple Choice");

--- a/yuquiz/src/pages/quiz/QuizFix.jsx
+++ b/yuquiz/src/pages/quiz/QuizFix.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { IoMdArrowBack } from "react-icons/io";
 import "../../styles/quiz/QuizFix.scss";
 
-export default function QuizFix() {
+export const QuizFix = () => {
   const [questionTitle, setQuestionTitle] = useState("");
   const [questionContent, setQuestionContent] = useState("");
   const [questionType, setQuestionType] = useState("");

--- a/yuquiz/src/pages/quiz/QuizListPage.jsx
+++ b/yuquiz/src/pages/quiz/QuizListPage.jsx
@@ -1,10 +1,11 @@
 // src/pages/QuizListPage.jsx
 
 import React, { useState } from 'react';
-import QuizList from '../components/quizlist/QuizList';
-import SearchBar from '../components/quizlist/SearchBar';
-import SubjectDropdown from '../components/quizlist/SubjectDropdown'; // 드롭다운 컴포넌트로 변경
-import '../styles/quiz_list_page/QuizListPage.scss';
+
+import '../../styles/quiz_list_page/QuizListPage.scss';
+import QuizList from '../../components/quizlist/QuizList';
+import SearchBar from '../../components/quizlist/SearchBar';
+import SubjectDropdown from '../../components/quizlist/SubjectDropdown';
 
 const QuizListPage = () => {
   const quizzesData = [

--- a/yuquiz/src/pages/register/Register.jsx
+++ b/yuquiz/src/pages/register/Register.jsx
@@ -1,13 +1,10 @@
-/**
- * v0 by Vercel.
- * @see https://v0.dev/t/4sYrEfEk5io
- * Documentation: https://v0.dev/docs#integrating-generated-code-into-your-nextjs-app
- */
-import '../../styles/Register.scss';
+
+import '../../styles/register/Register.scss';
 import { IoMdArrowBack } from "react-icons/io";
-export default function Register() {
+
+export const Register = () => {
     return (
-      <div className='root-container'>
+      <div className='register-container'>
         <button className="back-button"><IoMdArrowBack/></button>
         <div>
           <div className='title-container'>

--- a/yuquiz/src/routes/router.jsx
+++ b/yuquiz/src/routes/router.jsx
@@ -1,10 +1,116 @@
-import { createBrowserRouter } from "react-router-dom";
+import { createBrowserRouter, Outlet } from "react-router-dom";
 import Root from "../pages/Root";
+import EditProfile from "../pages/mypage/EditProfile";
+import QuizListPage from "../pages/quiz/QuizListPage";
+import PostListPage from "../pages/post/PostListPage";
+import { Login } from "../pages/login/Login";
+import { Register } from "../pages/register/Register";
+import MyPage from "../pages/mypage/MyPage";
+import { QuizCreator } from "../pages/quiz/QuizCreator";
+import { QuizFix } from "../pages/quiz/QuizFix";
+import PostCreator from "../pages/post/PostCreator";
+import PostFix from "../pages/post/PostFix";
+import PostView from "../pages/post/PostView";
+import MyPageLayout from "../pages/mypage/MyPageLayout";
 
 const router = createBrowserRouter([
   {
     path: "/",
-    element: <Root />, // Root 컴포넌트
+    element: (
+      <>
+        <Outlet />
+      </>
+    ),
+    children: [
+      {
+        index: true,
+        element: <Root />,
+      },
+      {
+        path: "login",
+        element: <Login />
+      },
+      {
+        path: "register",
+        element: <Register />, // 회원가입 컴포넌트
+      },
+      {
+        path: "my",
+        element: <MyPageLayout />, // 마이페이지 컴포넌트
+        children: [
+          {
+            index: true,
+            element: <MyPage />,
+          },
+          {
+            path: "edit",
+            element: <EditProfile />, // 정보 수정하기 컴포넌트
+          },
+        ],
+      },
+      {
+        path: "quiz",
+        element: (
+          <>
+            <Outlet />
+          </>
+        ),
+        children: [
+          {
+            path: "list",
+            element: <QuizListPage />, // 퀴즈 목록 컴포넌트
+          },
+          {
+            path: "create",
+            element: <QuizCreator />, // 퀴즈 생성 컴포넌트
+          },
+          {
+            path: "edit/:quizId",
+            element: <QuizFix />, // 퀴즈 수정 컴포넌트 (동적 경로)
+          },
+          {
+            path: "play/:quizId",
+            element: <QuizFix />, // 퀴즈 풀기 컴포넌트 (동적 경로)
+          },
+        ],
+      },
+      {
+        path: "posts",
+        element: (
+          <>
+            <Outlet />
+          </>
+        ),
+        children: [
+          {
+            path: "list",
+            element: <PostListPage />, // 게시글 목록 컴포넌트
+          },
+          {
+            path: "create",
+            element: <PostCreator />, // 게시글 생성 컴포넌트
+          },
+          {
+            path: "edit/:postId",
+            element: <PostFix />, // 게시글 수정 컴포넌트 (동적 경로)
+          },
+          {
+            path: "view/:postId",
+            element: <PostView />, // 게시글 조회 컴포넌트 (동적 경로)
+          },
+        ],
+      },
+      {
+        path: "admin",
+        element: <MyPageLayout />, // 관리자 페이지 컴포넌트
+        children: [
+          {
+            index: true,
+            element: <MyPage />,
+          }
+        ],
+      },
+    ],
   },
 ]);
 

--- a/yuquiz/src/styles/login/Login.scss
+++ b/yuquiz/src/styles/login/Login.scss
@@ -2,7 +2,7 @@ $primary-color : #00CBF7;
 $hover-color : #00caf778;
 
 
-.root-container{       
+.login-container{       
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/yuquiz/src/styles/mypage/EditProfile.scss
+++ b/yuquiz/src/styles/mypage/EditProfile.scss
@@ -1,114 +1,104 @@
-.mypage-container{
-    display: flex;
-    margin: 0 auto;  /* 중앙 정렬 */
-    padding: 20px;  /* 페이지 전체의 여백 */
-    gap: 20px;
-    height: 100vh;
+.edit-profile-container {
+  width: 100%;
+  margin: 0 auto;
+  padding: 20px;
+  background-color: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 8px;
 
-    .edit-profile-container {
-        width: 100%;
-        margin: 0 auto;
-        padding: 20px;
-        background-color: #f9f9f9;
-        border: 1px solid #ddd;
-        border-radius: 8px;
-      
-        h2 {
-          font-size: 24px;
-          font-weight: bold;
-          margin-bottom: 10px;
+  h2 {
+    font-size: 24px;
+    font-weight: bold;
+    margin-bottom: 10px;
+  }
+
+  p {
+    color: #777;
+    margin-bottom: 20px;
+  }
+
+  .edit-profile-form {
+    table {
+      width: 100%;
+      border-collapse: collapse;
+
+      th, td {
+        padding: 10px;
+        vertical-align: top;
+        text-align: left;
+        border-bottom: 1px solid #ddd;
+      }
+
+      th {
+        width: 200px;
+        font-weight: bold;
+        background-color: #f0f0f0;
+      }
+
+      td {
+        input[type="text"],
+        input[type="email"],
+        select {
+          width: 100%;
+          padding: 8px;
+          font-size: 14px;
+          border: 1px solid #ccc;
+          border-radius: 4px;
         }
-      
-        p {
-          color: #777;
-          margin-bottom: 20px;
+
+        .hint {
+          margin-top: 5px;
+          font-size: 12px;
+          color: #888;
         }
-      
-        .edit-profile-form {
-          table {
-            width: 100%;
-            border-collapse: collapse;
-      
-            th, td {
-              padding: 10px;
-              vertical-align: top;
-              text-align: left;
-              border-bottom: 1px solid #ddd;
-            }
-      
-            th {
-              width: 200px;
-              font-weight: bold;
-              background-color: #f0f0f0;
-            }
-      
-            td {
-              input[type="text"],
-              input[type="email"],
-              select {
-                width: 100%;
-                padding: 8px;
-                font-size: 14px;
-                border: 1px solid #ccc;
-                border-radius: 4px;
-              }
-      
-              .hint {
-                margin-top: 5px;
-                font-size: 12px;
-                color: #888;
-              }
-      
-              label {
-                font-size: 14px;
-              }
-      
-              input[type="checkbox"] {
-                margin-right: 5px;
-              }
-            }
-          }
-      
-          .submit-section {
-            display: flex;
-            justify-content: space-between; /* 양쪽 끝에 버튼 배치 */
-            margin-top: 20px;
-      
-            button {
-              padding: 10px 20px;
-              font-size: 14px;
-              font-weight: bold;
-              color: white;
-              background-color: #007bff;
-              border: none;
-              border-radius: 4px;
-              cursor: pointer;
-              transition: background-color 0.3s;
-      
-              &:hover {
-                background-color: #0056b3;
-              }
-            }
-      
-            .home-btn {
-              background-color: #6c757d; /* 홈으로 버튼 다른 색상 */
-              
-              &:hover {
-                background-color: #5a6268;
-              }
-            }
-      
-            .save-btn {
-              background-color: #007bff;
-      
-              &:hover {
-                background-color: #0056b3;
-              }
-            }
+
+        label {
+          font-size: 14px;
         }
+
+        input[type="checkbox"] {
+          margin-right: 5px;
         }
       }
+    }
+
+    .submit-section {
+      display: flex;
+      justify-content: space-between; /* 양쪽 끝에 버튼 배치 */
+      margin-top: 20px;
+
+      button {
+        padding: 10px 20px;
+        font-size: 14px;
+        font-weight: bold;
+        color: white;
+        background-color: #007bff;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        transition: background-color 0.3s;
+
+        &:hover {
+          background-color: #0056b3;
+        }
+      }
+
+      .home-btn {
+        background-color: #6c757d; /* 홈으로 버튼 다른 색상 */
+        
+        &:hover {
+          background-color: #5a6268;
+        }
+      }
+
+      .save-btn {
+        background-color: #007bff;
+
+        &:hover {
+          background-color: #0056b3;
+        }
+      }
+  }
+  }
 }
-
-
   

--- a/yuquiz/src/styles/mypage/MyPage.scss
+++ b/yuquiz/src/styles/mypage/MyPage.scss
@@ -1,38 +1,30 @@
-.mypage-container {
-    display: flex;
-    margin: 0 auto;  /* 중앙 정렬 */
-    padding: 20px;  /* 페이지 전체의 여백 */
-    gap: 20px;  /* ProfileCard와 Dashboard 사이의 간격 */
-    height: 100vh;
+.dashboard-container {
+  flex-grow: 1;  /* 남은 공간을 모두 사용 */
+  display: flex;
+  flex-direction: column;  /* 세로로 나열 */
+  justify-content: center;  /* 전체 대시보드를 세로로 중앙 정렬 */
 
-    .dashboard-container {
-        flex-grow: 1;  /* 남은 공간을 모두 사용 */
-        display: flex;
-        flex-direction: column;  /* 세로로 나열 */
-        justify-content: center;  /* 전체 대시보드를 세로로 중앙 정렬 */
-
-        button {
-            width: 100px;
-            padding: 10px 20px;
-            margin-bottom: 20px; /* 버튼과 아래 콘텐츠 사이에 여백 추가 */
-            border: none;
-            border-radius: 8px;
-            background-color: #007bff;
-            color: #fff;
-            font-size: 16px;
-            cursor: pointer;
-            transition: background-color 0.3s, transform 0.3s;
-          
-            &:hover {
-              background-color: #0056b3;
-            }
-          
-          }
-
-        .row {
-            display: flex;
-            gap: 20px;  /* 각 ListBox 컴포넌트 사이의 간격 */
-            margin-bottom: 20px;  /* 각 row 사이의 간격 */
-        }
+  .my-home-btn {
+      width: 100px;
+      padding: 10px 20px;
+      margin-bottom: 20px; /* 버튼과 아래 콘텐츠 사이에 여백 추가 */
+      border: none;
+      border-radius: 8px;
+      background-color: #000000;
+      color: #fff;
+      font-size: 16px;
+      cursor: pointer;
+      transition: background-color 0.3s, transform 0.3s;
+    
+      &:hover {
+        background-color: #0056b3;
+      }
+    
     }
+
+  .row {
+      display: flex;
+      gap: 20px;  /* 각 ListBox 컴포넌트 사이의 간격 */
+      margin-bottom: 20px;  /* 각 row 사이의 간격 */
+  }
 }

--- a/yuquiz/src/styles/mypage/MyPageLayout.scss
+++ b/yuquiz/src/styles/mypage/MyPageLayout.scss
@@ -1,0 +1,7 @@
+.mypage-container {
+    display: flex;
+    margin: 0 auto;  /* 중앙 정렬 */
+    padding: 20px;  /* 페이지 전체의 여백 */
+    gap: 20px;  /* ProfileCard와 Dashboard 사이의 간격 */
+    height: 100vh;
+}

--- a/yuquiz/src/styles/post_list_page/SearchBar.scss
+++ b/yuquiz/src/styles/post_list_page/SearchBar.scss
@@ -1,6 +1,6 @@
 /* src/styles/SearchBar.scss */
 
-.search-bar {
+.post-search-bar {
     display: flex;
     justify-content: center;
     margin: 20px 0;
@@ -14,7 +14,7 @@
       margin-right: 10px;
     }
   
-    button {
+    .post-search-btn {
       padding: 10px 20px;
       background-color: #000;
       color: #fff;

--- a/yuquiz/src/styles/quiz_list_page/SearchBar.scss
+++ b/yuquiz/src/styles/quiz_list_page/SearchBar.scss
@@ -1,6 +1,6 @@
 /* src/styles/SearchBar.scss */
 
-.search-bar {
+.quiz-search-bar {
     display: flex;
     justify-content: center;
     margin: 20px 0;
@@ -14,7 +14,7 @@
       margin-right: 10px;
     }
   
-    button {
+    .quiz-search-btn {
       padding: 10px 20px;
       background-color: #000;
       color: #fff;

--- a/yuquiz/src/styles/register/Register.scss
+++ b/yuquiz/src/styles/register/Register.scss
@@ -1,15 +1,15 @@
 $primary-color : #00CBF7;
 $hover-color : #00caf778;
 
-body{
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100vh;
-    margin: 0;
-}
+// body{
+//     display: flex;
+//     align-items: center;
+//     justify-content: center;
+//     height: 100vh;
+//     margin: 0;
+// }
 
-.root-container{       
+.register-container{       
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/yuquiz/src/styles/root/ProfileCard.scss
+++ b/yuquiz/src/styles/root/ProfileCard.scss
@@ -1,4 +1,4 @@
-.profile-container {
+.root-profile-container {
     display: flex;
     flex-direction: column;
     border: 1px solid #ccc;

--- a/yuquiz/yarn.lock
+++ b/yuquiz/yarn.lock
@@ -7931,7 +7931,7 @@ react-refresh@^0.11.0:
 
 react-router-dom@^6.26.1:
   version "6.26.1"
-  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.1.tgz"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.26.1.tgz#a408892b41767a49dc94b3564b0e7d8e3959f623"
   integrity sha512-veut7m41S1fLql4pLhxeSW3jlqs+4MtjRLj0xvuCEXsxusJCbs6I8yn9BxzzDX2XDgafrccY6hwjmd/bL54tFw==
   dependencies:
     "@remix-run/router" "1.19.1"


### PR DESCRIPTION
## 개요

라우터를 설정하여 이제 주소를 통해 여러 페이지로 이동할 수 있습니다.

## 구현 사항

- MyPageLayout 페이지를 추가하여 마이페이지에서 보여야할 기본 프로필카드를 넣었습니다. 이제 따로 프로필카드를 넣지 않아도 보여집니다.
- 라우터를 설정하여 outlet을 통해 하위 디렉토리로 이동할 수 있습니다.
- 기존 scss classname이 겹치는 부분이 있습니다. 일부 수정하였습니다.

## 기타

Link 태그를 통해 버튼을 통해 페이지 이동을 추후 구현하려 합니다.
아직 scss파일의 className이 따로 정해져있지 않거나(button, input 등..) className이 겹치는 부분이 있습니다. 모든 className을 다르게 설정 부탁드립니다.