### PR TITLE
feat: 퀴즈 생성창 api 연결 및 구조 수정

### DIFF
--- a/yuquiz/src/pages/quiz/QuizCreator.jsx
+++ b/yuquiz/src/pages/quiz/QuizCreator.jsx
@@ -82,13 +82,13 @@ export const QuizCreator = () => {
       title: questionTitle,
       question: questionContent,
       quizImg: image,
-      answer: answer, // 정답 번호가 저장된 문자열
+      answer: answer,
       quizType: questionType,
-      choices: choices, // 사용자가 입력한 답안 내용
+      choices: choices,
       subjectId: 2,
     };
 
-    handlerSubmitQuiz(data); // 수정된 데이터를 서브밋 함수로 전달
+    handlerSubmitQuiz(data);
   };
 
   return (

--- a/yuquiz/src/pages/quiz/QuizCreator.jsx
+++ b/yuquiz/src/pages/quiz/QuizCreator.jsx
@@ -2,11 +2,12 @@ import React, { useState, useEffect, useRef } from "react";
 import { IoMdArrowBack } from "react-icons/io";
 import "../../styles/quiz/QuizCreator.scss";
 import { Link } from "react-router-dom";
+import { handlerSubmitQuiz } from "../../services/quiz/quizCreator";
 
 export const QuizCreator = () => {
   const [questionTitle, setQuestionTitle] = useState("");
   const [questionContent, setQuestionContent] = useState("");
-  const [questionType, setQuestionType] = useState("Multiple Choice");
+  const [questionType, setQuestionType] = useState("MULTIPLE_CHOICE");
   const [answers, setAnswers] = useState([
     { num: 1, text: "", correct: false },
     { num: 2, text: "", correct: false },
@@ -32,7 +33,7 @@ export const QuizCreator = () => {
         { num: 1, text: "True", correct: false },
         { num: 2, text: "False", correct: false },
       ]);
-    } else if (questionType === "Short Answer") {
+    } else if (questionType === "SHORT_ANSWER") {
       setAnswers([{ num: 1, text: "", correct: true }]); // 단답식은 하나의 정답만 존재
     } else {
       setAnswers([
@@ -50,18 +51,51 @@ export const QuizCreator = () => {
     setAnswers(newAnswers);
   };
 
-  const handleAddQuestion = () => {
-    // 추후 추가
-    // 빈 답들이 입력되었을때 처리하는 로직
-  };
-
   const handleSubmitQuiz = () => {
-    // 추후 추가
+    // Multiple Choice: 정답 번호를 문자열로 저장
+    let answer = "";
+
+    if (questionType === "MULTIPLE_CHOICE") {
+      const correctAnswers = answers
+        .filter((answer) => answer.correct) // correct가 true인 답안만 필터링
+        .map((answer) => answer.num) // 정답 번호 추출
+        .sort((a, b) => a - b); // 오름차순 정렬
+
+      answer = correctAnswers.join(""); // 번호를 문자열로 합침 (예: "13")
+    }
+
+    // True/False: 정답이 True면 "1", False면 "0"으로 저장
+    if (questionType === "TRUE_FALSE") {
+      const correctAnswer = answers.find((answer) => answer.correct);
+      answer = correctAnswer ? "1" : "0"; // True이면 "1", False이면 "0"
+    }
+
+    // Short Answer: 단답형은 단일 정답이므로 정답 번호는 "1"로 고정
+    if (questionType === "SHORT_ANSWER") {
+      answer = "1"; // 단답형의 경우 정답은 하나뿐이므로 "1"로 고정
+    }
+
+    // 사용자가 입력한 답안 내용은 choices에 배열로 저장
+    const choices = answers.map((answer) => answer.text);
+
+    const data = {
+      title: questionTitle,
+      question: questionContent,
+      quizImg: image,
+      answer: answer, // 정답 번호가 저장된 문자열
+      quizType: questionType,
+      choices: choices, // 사용자가 입력한 답안 내용
+      subjectId: 2,
+    };
+
+    handlerSubmitQuiz(data); // 수정된 데이터를 서브밋 함수로 전달
   };
 
   return (
     <div>
-      <Link to='/quiz/list' className="back-button"><IoMdArrowBack /></Link>
+      <Link to="/quiz/list" className="back-button">
+        <IoMdArrowBack />
+      </Link>
       <div className="container">
         <div className="quiz-creator">
           <h2 className="title">Quiz 생성</h2>
@@ -88,14 +122,14 @@ export const QuizCreator = () => {
               value={questionType}
               onChange={(e) => setQuestionType(e.target.value)}
             >
-              <option value="Multiple Choice">중복 정답</option>
-              <option value="True/False">O/X</option>
-              <option value="Short Answer">단답식</option>
+              <option value="MULTIPLE_CHOICE">중복 정답</option>
+              <option value="TRUE_FALSE">O/X</option>
+              <option value="SHORT_ANSWER">단답식</option>
             </select>
           </div>
 
           <div className="answers-container">
-            {questionType === "Multiple Choice" &&
+            {questionType === "MULTIPLE_CHOICE" &&
               answers.map((answer, index) => (
                 <div key={index} className="answer-group">
                   <label className="answer-label" htmlFor={`answer-${index}`}>
@@ -117,12 +151,12 @@ export const QuizCreator = () => {
                         handleAnswerChange(index, "correct", e.target.checked)
                       }
                     />
-                    Correct
+                    정답 (중복가능)
                   </label>
                 </div>
               ))}
 
-            {questionType === "True/False" &&
+            {questionType === "TRUE_FALSE" &&
               answers.map((answer, index) => (
                 <div key={index} className="answer-group">
                   <label className="answer-label" htmlFor={`answer-${index}`}>
@@ -140,7 +174,7 @@ export const QuizCreator = () => {
                 </div>
               ))}
 
-            {questionType === "Short Answer" && (
+            {questionType === " SHORT_ANSWER" && (
               <div className="answer-group">
                 <label className="answer-label" htmlFor={`answer-1`}>
                   정답
@@ -152,6 +186,7 @@ export const QuizCreator = () => {
                   onChange={(e) =>
                     handleAnswerChange(0, "text", e.target.value)
                   }
+                  placeholder="띄어쓰기금지"
                 />
               </div>
             )}
@@ -173,4 +208,4 @@ export const QuizCreator = () => {
       </div>
     </div>
   );
-}
+};

--- a/yuquiz/src/services/auth/login/authService.js
+++ b/yuquiz/src/services/auth/login/authService.js
@@ -2,9 +2,11 @@ import api from '../../apiService';
 import { setAccessToken, removeAccessToken } from '../../../utils/token';
 import useAuthStore from '../../../stores/auth/authStore';
 
+const SERVER_API = process.env.REACT_APP_YUQUIZ;
+
 const login = async (username, password) => {
   try {
-    const response = await api.post(`/auth/sign-in`, { username, password });
+    const response = await api.post(`${SERVER_API}/auth/sign-in`, { username, password });
     const { accessToken } = response.data;
 
     setAccessToken(accessToken); // sessionStorage에 Access Token 저장
@@ -30,7 +32,7 @@ const logout = async () => {
   try {
     const accessToken = useAuthStore.getState().accessToken;
 
-    const response = await api.get(`/auth/sign-out`, {
+    const response = await api.get(`${SERVER_API}/auth/sign-out`, {
       headers: {
         Authorization: `Bearer ${accessToken}`, // Access Token 포함
       },

--- a/yuquiz/src/services/quiz/quizCreator.js
+++ b/yuquiz/src/services/quiz/quizCreator.js
@@ -1,0 +1,17 @@
+import axios, { HttpStatusCode } from 'axios';
+
+const SERVER_API = process.env.REACT_APP_YUQUIZ;
+
+const handlerSubmitQuiz =async (data)=>{
+    try{
+        const response = await axios.post(`${SERVER_API}/quizzes`, data);
+        if (response.status === HttpStatusCode.Ok) {
+            alert(response.response||"퀴즈 생성 완료!");
+            return true;
+        } 
+    }
+    catch{  
+        alert("퀴즈가 유효하지 않습니다.");
+    }
+}
+export {handlerSubmitQuiz};


### PR DESCRIPTION
## 개요

퀴즈 생성창 api 연결 및 구조 수정

## 구현 사항

- 퀴즈의 답을 선택하는 순서에 상관없이 정렬해서 String으로 합쳐서 넘겨줌
- 기존의 choice들을 넘겨주는 것에 문제(서버와의 통신에서 형식의 오해)가 있었는데 정해진 규칙에 맞도록 올바르게 구현을 함.
- 번외로 로그인 부분에 api부분을 전부 잘못 적어놔서 다시 `{api주소}/`형식으로 교체함.
## 기타

추후 백엔드에서 과목에 대한 api들을 구현하면 과목 선택하고 넘겨주는 것 추가해야함.