### PR TITLE
feat: quiz 리스트 페이지 구현

### DIFF
--- a/yuquiz/src/components/quizlist/QuizList.jsx
+++ b/yuquiz/src/components/quizlist/QuizList.jsx
@@ -1,17 +1,19 @@
-import '../../styles/quiz_list_page/QuizList.scss';
+import "../../styles/quiz_list_page/QuizList.scss";
+import React from "react";
+import QuizListItem from "./QuizListItem";
 
-const QuizList = ({currentQuizzes}) =>{
-    return(
-        <div className="quiz-list-container">
-        {currentQuizzes.map((quiz) => (
-          <div key={quiz.id} className="quiz-card">
-            <div className="quiz-type">{quiz.type}</div>
-            <div className="quiz-question">{quiz.question}</div>
-            <button className="quiz-button">퀴즈 풀기</button>
-          </div>
-        ))}
-      </div>
-    );
-}
+const QuizList = ({ currentQuizzes }) => {
+  return (
+    <div className="quiz-list">
+      {currentQuizzes.length === 0 ? (
+        <p>표시할 퀴즈가 없습니다.</p>
+      ) : (
+        currentQuizzes.map((quiz) => (
+          <QuizListItem key={quiz.quizId} quiz={quiz} />
+        ))
+      )}
+    </div>
+  );
+};
 
 export default QuizList;

--- a/yuquiz/src/components/quizlist/QuizListItem.jsx
+++ b/yuquiz/src/components/quizlist/QuizListItem.jsx
@@ -1,6 +1,7 @@
 // src/components/quizlist/QuizListItem.jsx
 import React from "react";
 import "../../styles/quiz_list_page/QuizListItem.scss";
+
 const QuizListItem = ({ quiz }) => {
   const {
     quizTitle,
@@ -9,14 +10,31 @@ const QuizListItem = ({ quiz }) => {
     viewCount,
     createdAt,
     isSolved,
-    type,
+    quizType,
+    subject,
   } = quiz;
+
+  // 퀴즈 유형 변환 함수
+  const getQuizTypeLabel = (quizType) => {
+    switch (quizType) {
+      case "MULTIPLE_CHOICE":
+        return "객관식";
+      case "TRUE_FALSE":
+        return "O/X";
+      case "SHORT_ANSWER":
+        return "단답식";
+      default:
+        return "일반"; // 기본값
+    }
+  };
 
   return (
     <div className="quiz-list-item">
       <div className="quiz-header">
         <h2 className="quiz-title">{quizTitle}</h2>
-        <p className="quiz-type">{type || "일반"}</p> {/* 퀴즈 유형 표시 */}
+        <p className="quiz-type">{getQuizTypeLabel(quizType)}</p>{" "}
+        {/* 퀴즈 유형 표시 */}
+        <p className="quiz-type">{subject || "과목"}</p> {/* 퀴즈 과목 표시 */}
       </div>
 
       <div className="quiz-info-container">

--- a/yuquiz/src/components/quizlist/QuizListItem.jsx
+++ b/yuquiz/src/components/quizlist/QuizListItem.jsx
@@ -1,0 +1,41 @@
+// src/components/quizlist/QuizListItem.jsx
+import React from "react";
+import "../../styles/quiz_list_page/QuizListItem.scss";
+const QuizListItem = ({ quiz }) => {
+  const {
+    quizTitle,
+    nickname,
+    likeCount,
+    viewCount,
+    createdAt,
+    isSolved,
+    type,
+  } = quiz;
+
+  return (
+    <div className="quiz-list-item">
+      <div className="quiz-header">
+        <h2 className="quiz-title">{quizTitle}</h2>
+        <p className="quiz-type">{type || "일반"}</p> {/* 퀴즈 유형 표시 */}
+      </div>
+
+      <div className="quiz-info-container">
+        <div className="quiz-stats">
+          <p className="quiz-likes">👍 {likeCount}</p>
+          <p className="quiz-views">조회수: {viewCount}</p>
+          <p className={`quiz-solved ${isSolved ? "solved" : "unsolved"}`}>
+            {isSolved ? "풀이 완료" : ""}
+          </p>
+        </div>
+        <div className="quiz-meta">
+          <p className="quiz-author">작성자: {nickname}</p>
+          <p className="quiz-date">
+            작성일: {new Date(createdAt).toLocaleDateString()}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuizListItem;

--- a/yuquiz/src/pages/quiz/QuizListPage.jsx
+++ b/yuquiz/src/pages/quiz/QuizListPage.jsx
@@ -1,50 +1,76 @@
 // src/pages/QuizListPage.jsx
 
-import React, { useState } from "react";
-
+import React, { useState, useEffect } from "react";
 import "../../styles/quiz_list_page/QuizListPage.scss";
 import QuizList from "../../components/quizlist/QuizList";
 import SearchBar from "../../components/quizlist/SearchBar";
 import SubjectDropdown from "../../components/quizlist/SubjectDropdown";
 import { Link } from "react-router-dom";
+import { getQuizList } from "../../services/quiz/QuizManage";
 
 const QuizListPage = () => {
-  const quizzesData = [
-    {
-      id: 1,
-      type: "O/X",
-      question: "What is the capital city of France?",
-      subject: "Geography",
-    },
-    {
-      id: 2,
-      type: "선다형",
-      question: "Who was the first president of the United States?",
-      subject: "History",
-    },
-    {
-      id: 3,
-      type: "단답형",
-      question: "What is the chemical symbol for gold?",
-      subject: "Chemistry",
-    },
-    {
-      id: 4,
-      type: "O/X",
-      question: "What is the capital city of France?",
-      subject: "Geography",
-    },
-    // 추가 데이터...
-  ];
+  const [quizzes, setQuizzes] = useState([]);
+  const [filteredQuizzes, setFilteredQuizzes] = useState([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedSubject, setSelectedSubject] = useState("All");
+  const [currentPage, setCurrentPage] = useState(null); // 현재 페이지
+  const [totalPages, setTotalPages] = useState(1); // 전체 페이지 수
+  const [isLoading, setIsLoading] = useState(false); // 로딩 상태
+  const [error, setError] = useState(null); // 에러 상태
 
-  const [subjects] = useState(["All", "Geography", "History", "Chemistry"]);
+  const subjects = ["All", "Geography", "History", "Chemistry"];
+
+  useEffect(() => {
+    const fetchQuizzes = async () => {
+      setIsLoading(true);
+      setError(null); // 에러 초기화
+      try {
+        const quizData = await getQuizList(currentPage); // 서버에서 퀴즈 목록 가져오기
+        setQuizzes(quizData.content);
+        setFilteredQuizzes(quizData.content); // 필터링 전 전체 퀴즈 저장
+        setTotalPages(quizData.totalPages); // 전체 페이지 수 저장
+      } catch (error) {
+        setError("퀴즈 목록을 불러오지 못했습니다."); // 에러 메시지 설정
+        console.error(error);
+      } finally {
+        setIsLoading(false); // 로딩 완료
+      }
+    };
+    fetchQuizzes();
+  }, [currentPage]); // currentPage 변경 시마다 호출
 
   const handleSearch = (query) => {
-    // 검색 로직 작성
+    setSearchQuery(query);
+    filterQuizzes(query, selectedSubject);
   };
 
   const handleSelectSubject = (subject) => {
-    // 과목 선택 로직 작성
+    setSelectedSubject(subject);
+    filterQuizzes(searchQuery, subject);
+  };
+
+  const filterQuizzes = (query, subject) => {
+    let filtered = quizzes;
+
+    // 검색어로 필터링
+    if (query) {
+      filtered = filtered.filter((quiz) =>
+        quiz.quizTitle.toLowerCase().includes(query.toLowerCase())
+      );
+    }
+
+    // 과목으로 필터링 (예시로 subject 필터 적용)
+    if (subject !== "All") {
+      filtered = filtered.filter(
+        (quiz) => (quiz.subject ? quiz.subject === subject : true) // subject 필드가 있다고 가정
+      );
+    }
+
+    setFilteredQuizzes(filtered);
+  };
+
+  const handlePageChange = (page) => {
+    setCurrentPage(page); // 페이지 변경
   };
 
   return (
@@ -57,6 +83,7 @@ const QuizListPage = () => {
           마이페이지
         </Link>
       </nav>
+
       <div className="controls-container">
         <SearchBar onSearch={handleSearch} />
         <SubjectDropdown
@@ -64,7 +91,32 @@ const QuizListPage = () => {
           onSelectSubject={handleSelectSubject}
         />
       </div>
-      <QuizList currentQuizzes={quizzesData} />
+
+      {/* 로딩 상태 표시 */}
+      {isLoading && <p>로딩 중...</p>}
+
+      {/* 에러 메시지 표시 */}
+      {error && <p className="error-message">{error}</p>}
+
+      {/* 퀴즈 리스트 */}
+      {!isLoading && !error && filteredQuizzes.length === 0 && (
+        <p>표시할 퀴즈가 없습니다.</p>
+      )}
+      <QuizList currentQuizzes={filteredQuizzes} />
+
+      {/* 페이징 버튼 */}
+      <div className="pagination-container">
+        {Array.from({ length: totalPages }, (_, index) => (
+          <button
+            key={index}
+            className={`page-button ${index === currentPage ? "active" : ""}`}
+            onClick={() => handlePageChange(index)}
+            disabled={index === currentPage} // 현재 페이지일 경우 비활성화
+          >
+            {index + 1}
+          </button>
+        ))}
+      </div>
     </div>
   );
 };

--- a/yuquiz/src/pages/quiz/QuizListPage.jsx
+++ b/yuquiz/src/pages/quiz/QuizListPage.jsx
@@ -100,7 +100,7 @@ const QuizListPage = () => {
 
       {/* 퀴즈 리스트 */}
       {!isLoading && !error && filteredQuizzes.length === 0 && (
-        <p>표시할 퀴즈가 없습니다.</p>
+        <p>아직은 표시할 퀴즈가 없습니다.</p>
       )}
       <QuizList currentQuizzes={filteredQuizzes} />
 

--- a/yuquiz/src/pages/quiz/QuizListPage.jsx
+++ b/yuquiz/src/pages/quiz/QuizListPage.jsx
@@ -1,23 +1,43 @@
 // src/pages/QuizListPage.jsx
 
-import React, { useState } from 'react';
+import React, { useState } from "react";
 
-import '../../styles/quiz_list_page/QuizListPage.scss';
-import QuizList from '../../components/quizlist/QuizList';
-import SearchBar from '../../components/quizlist/SearchBar';
-import SubjectDropdown from '../../components/quizlist/SubjectDropdown';
-import { Link } from 'react-router-dom';
+import "../../styles/quiz_list_page/QuizListPage.scss";
+import QuizList from "../../components/quizlist/QuizList";
+import SearchBar from "../../components/quizlist/SearchBar";
+import SubjectDropdown from "../../components/quizlist/SubjectDropdown";
+import { Link } from "react-router-dom";
 
 const QuizListPage = () => {
   const quizzesData = [
-    { id: 1, type: 'O/X', question: 'What is the capital city of France?', subject: 'Geography' },
-    { id: 2, type: '선다형', question: 'Who was the first president of the United States?', subject: 'History' },
-    { id: 3, type: '단답형', question: 'What is the chemical symbol for gold?', subject: 'Chemistry' },
-    { id: 4, type: 'O/X', question: 'What is the capital city of France?', subject: 'Geography' },
+    {
+      id: 1,
+      type: "O/X",
+      question: "What is the capital city of France?",
+      subject: "Geography",
+    },
+    {
+      id: 2,
+      type: "선다형",
+      question: "Who was the first president of the United States?",
+      subject: "History",
+    },
+    {
+      id: 3,
+      type: "단답형",
+      question: "What is the chemical symbol for gold?",
+      subject: "Chemistry",
+    },
+    {
+      id: 4,
+      type: "O/X",
+      question: "What is the capital city of France?",
+      subject: "Geography",
+    },
     // 추가 데이터...
   ];
 
-  const [subjects] = useState(['All', 'Geography', 'History', 'Chemistry']);
+  const [subjects] = useState(["All", "Geography", "History", "Chemistry"]);
 
   const handleSearch = (query) => {
     // 검색 로직 작성
@@ -30,12 +50,19 @@ const QuizListPage = () => {
   return (
     <div className="quiz-list-page-container">
       <nav className="navbar">
-        <Link to='/' className="nav-button">홈으로</Link>
-        <Link to='/my' className="nav-button">마이페이지</Link>
+        <Link to="/" className="nav-button">
+          홈으로
+        </Link>
+        <Link to="/my" className="nav-button">
+          마이페이지
+        </Link>
       </nav>
-      <div className='controls-container'>
+      <div className="controls-container">
         <SearchBar onSearch={handleSearch} />
-        <SubjectDropdown subjects={subjects} onSelectSubject={handleSelectSubject} />
+        <SubjectDropdown
+          subjects={subjects}
+          onSelectSubject={handleSelectSubject}
+        />
       </div>
       <QuizList currentQuizzes={quizzesData} />
     </div>

--- a/yuquiz/src/services/apiService.js
+++ b/yuquiz/src/services/apiService.js
@@ -1,6 +1,6 @@
-import axios, { HttpStatusCode } from 'axios';
-import useAuthStore from '../stores/auth/authStore';
-import { setAccessToken, removeAccessToken } from '../utils/token';
+import axios, { HttpStatusCode } from "axios";
+import useAuthStore from "../stores/auth/authStore";
+import { setAccessToken, removeAccessToken } from "../utils/token";
 
 const SERVER_API = process.env.REACT_APP_YUQUIZ;
 
@@ -26,14 +26,22 @@ api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const originalRequest = error.config;
-    if (error.response && error.response.status === HttpStatusCode.Unauthorized && !originalRequest._retry) {
+    if (
+      error.response &&
+      error.response.status === HttpStatusCode.Unauthorized &&
+      !originalRequest._retry
+    ) {
       originalRequest._retry = true;
 
       try {
         // Refresh Token으로 Access Token 갱신
-        const response = await axios.post(`${SERVER_API}/auth/token/refresh`, {}, {
-          withCredentials: true, // 쿠키로 Refresh Token 전송
-        });
+        const response = await axios.post(
+          `${SERVER_API}/auth/token/refresh`,
+          {},
+          {
+            withCredentials: true, // 쿠키로 Refresh Token 전송
+          }
+        );
 
         const { accessToken } = response.data;
         useAuthStore.getState().setAccessToken(accessToken); // 새로운 Access Token 상태에 저장

--- a/yuquiz/src/services/quiz/QuizManage.js
+++ b/yuquiz/src/services/quiz/QuizManage.js
@@ -1,1 +1,47 @@
-// 퀴즈 불러오기 getQuiz, 퀴즈 수정하기 fixQuiz, 퀴즈 삭제하기 deleteQuiz
+import api from "../apiService";
+const SERVER_API = process.env.REACT_APP_YUQUIZ;
+
+// sort 값을 위한 enum (API에서 허용하는 값들)
+const SORT_OPTIONS = {
+  LIKE_DESC: "LIKE_DESC",
+  LIKE_ASC: "LIKE_ASC",
+  VIEW_DESC: "VIEW_DESC",
+  VIEW_ASC: "VIEW_ASC",
+  DATE_DESC: "DATE_DESC",
+  DATE_ASC: "DATE_ASC",
+};
+
+const getQuizList = async (
+  keyword = "",
+  subject = null,
+  sort = SORT_OPTIONS.DATE_DESC,
+  page = 0
+) => {
+  try {
+    // 유효한 값만 params에 포함시키는 방법
+    const params = {};
+
+    if (keyword) params.keyword = keyword;
+    if (subject) params.subject = subject; // subject가 숫자 값일 것으로 가정
+    if (sort && Object.values(SORT_OPTIONS).includes(sort)) {
+      params.sort = sort;
+    } else {
+      params.sort = SORT_OPTIONS.DATE_DESC; // 기본값 설정
+    }
+    if (page >= 0) params.page = page;
+
+    // API 호출
+    const response = await api.get(`${SERVER_API}/quizzes`, { params });
+    console.log(response.data);
+
+    return response.data;
+  } catch (error) {
+    if (error.response) {
+      throw new Error("퀴즈 목록 불러오는 중 문제 발생. 다시 시도해주세요.");
+    } else {
+      throw new Error("서버와 연결할 수 없습니다.");
+    }
+  }
+};
+
+export { getQuizList, SORT_OPTIONS };

--- a/yuquiz/src/services/quiz/QuizManage.js
+++ b/yuquiz/src/services/quiz/QuizManage.js
@@ -1,0 +1,1 @@
+// 퀴즈 불러오기 getQuiz, 퀴즈 수정하기 fixQuiz, 퀴즈 삭제하기 deleteQuiz

--- a/yuquiz/src/services/quiz/quizCreator.js
+++ b/yuquiz/src/services/quiz/quizCreator.js
@@ -1,16 +1,9 @@
-import axios, { HttpStatusCode } from 'axios';
-import { getAccessToken } from '../../utils/token';
-
+import { HttpStatusCode } from 'axios';
+import api from '../apiService';
 const SERVER_API = process.env.REACT_APP_YUQUIZ;
-const accessToken = getAccessToken();
 const handlerSubmitQuiz =async (data)=>{
     try{
-        const response = await axios.post(`${SERVER_API}/quizzes`, data, {
-            headers: {
-              'Authorization': `${accessToken}`, 
-              'Content-Type': 'application/json',
-            },
-          });
+        const response = await api.post(`${SERVER_API}/quizzes`, data);
         if (response.status === HttpStatusCode.Ok) {
             alert(response.response||"퀴즈 생성 완료!");
             return true;

--- a/yuquiz/src/styles/quiz_list_page/QuizListItem.scss
+++ b/yuquiz/src/styles/quiz_list_page/QuizListItem.scss
@@ -1,0 +1,73 @@
+// src/styles/quiz_list_page/QuizListItem.scss
+
+.quiz-list-item {
+    border: 1px solid #ddd;
+    padding: 16px;
+    margin-bottom: 16px;
+    border-radius: 8px;
+    background-color: #fff;
+  }
+  .quiz-info-container{
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    .quiz-meta {
+    width: 50%;
+    align-items: end;
+    justify-content: end;
+    display: flex;
+    flex-direction: column;
+    font-size: 0.9rem;
+    margin-top: 8px;
+    }
+    .quiz-stats {
+    width: 50%;
+    display: flex;
+    align-items: start;
+    flex-direction: column;
+    margin-top: 12px;
+    }
+  }  
+  .quiz-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  
+  .quiz-title {
+    font-size: 1.5rem;
+    font-weight: bold;
+  }
+  
+  .quiz-type {
+    font-size: 0.9rem;
+    color: #666;
+  }
+  
+  
+  
+  .quiz-author,
+  .quiz-date {
+    color: #888;
+  }
+  
+
+  
+  .quiz-likes,
+  .quiz-views {
+    font-size: 1rem;
+    color: #555;
+  }
+  
+  .quiz-solved {
+    font-weight: bold;
+  }
+  
+  .solved {
+    color: green;
+  }
+  
+  .unsolved {
+    color: red;
+  }
+  

--- a/yuquiz/src/styles/quiz_list_page/QuizListItem.scss
+++ b/yuquiz/src/styles/quiz_list_page/QuizListItem.scss
@@ -30,22 +30,23 @@
   }  
   .quiz-header {
     display: flex;
-    justify-content: space-between;
+    justify-content: start;
     align-items: center;
   }
   
   .quiz-title {
     font-size: 1.5rem;
     font-weight: bold;
+    margin-right: 10px;
   }
   
   .quiz-type {
+    margin-right: 10px;
     font-size: 0.9rem;
-    color: #666;
+    color: black;
+    background-color: rgb(207, 201, 201);
+    border-radius: 2px;
   }
-  
-  
-  
   .quiz-author,
   .quiz-date {
     color: #888;

--- a/yuquiz/src/styles/quiz_list_page/QuizListPage.scss
+++ b/yuquiz/src/styles/quiz_list_page/QuizListPage.scss
@@ -27,8 +27,30 @@
   }
 }
 
+/* src/styles/quiz_list_page/QuizListPage.scss */
 
+.pagination-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 20px;
+  padding: 10px;
+}
 
+.page-button {
+  margin: 0 5px;
+  padding: 10px 20px; /* 버튼을 크게 만듦 */
+  background-color: #007bff;
+  color: white;
+  border: none;
+  cursor: pointer;
+  border-radius: 5px;
+  font-size: 16px; /* 글씨 크기 키움 */
+}
 
+.page-button.active {
+  background-color: #0056b3; /* 활성화된 버튼 색상 */
+}
 
-
+.page-button:hover {
+  background-color: #0056b3; /* 호버 시 색상 */
+}

--- a/yuquiz/src/styles/quiz_list_page/SearchBar.scss
+++ b/yuquiz/src/styles/quiz_list_page/SearchBar.scss
@@ -1,31 +1,36 @@
 /* src/styles/SearchBar.scss */
 
 .quiz-search-bar {
+  display: flex;
+  justify-content: center;
+  margin: 20px 0;
+
+  input {
+    padding: 10px;
+    font-size: 16px;
+    width: 400px; /* 입력 필드가 더 넓게 보이도록 설정 */
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    margin-right: 10px;
+  }
+
+  .quiz-search-btn {
+    padding: 10px 20px;
+    background-color: #000;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
     display: flex;
+    align-items: center;
     justify-content: center;
-    margin: 20px 0;
-  
-    input {
-      padding: 10px;
-      font-size: 16px;
-      width: 400px;  /* 입력 필드가 더 넓게 보이도록 설정 */
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      margin-right: 10px;
-    }
-  
-    .quiz-search-btn {
-      padding: 10px 20px;
-      background-color: #000;
-      color: #fff;
-      border: none;
-      border-radius: 4px;
-      cursor: pointer;
-      transition: background-color 0.3s ease;
-  
-      &:hover {
-        background-color: #444;
-      }
+    height: fit-content;
+    width: fit-content;
+    white-space: nowrap; /* 글자가 줄바꿈되지 않도록 설정 */
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+
+    &:hover {
+      background-color: #444;
     }
   }
-  
+}


### PR DESCRIPTION
## 개요

퀴즈 리스트 페이지 기능연결

## 구현 사항

- 퀴즈리스트 불러오기
- 페이징
- 퀴즈 타입 및 여러가지 정보 화면에 출력
- 풀면 풀었다고 표시하게 됨

## 기타

이제 퀴즈 내부로 들어가서 수정 및 삭제를 구현하고 풀 수 있도록 하는 작업 필요

## 이미지

![image](https://github.com/user-attachments/assets/7a1911b8-eb72-45ef-b62a-87d0e8361a8e)
