### PR TITLE
feat: 퀴즈 푸는 페이지 구현 및 수정, 삭제 구현

### DIFF
--- a/yuquiz/src/components/quizlist/QuizListItem.jsx
+++ b/yuquiz/src/components/quizlist/QuizListItem.jsx
@@ -1,9 +1,11 @@
 // src/components/quizlist/QuizListItem.jsx
 import React from "react";
 import "../../styles/quiz_list_page/QuizListItem.scss";
+import { Link } from "react-router-dom";
 
 const QuizListItem = ({ quiz }) => {
   const {
+    quizId,
     quizTitle,
     nickname,
     likeCount,
@@ -31,12 +33,13 @@ const QuizListItem = ({ quiz }) => {
   return (
     <div className="quiz-list-item">
       <div className="quiz-header">
-        <h2 className="quiz-title">{quizTitle}</h2>
+        <h2 className="quiz-title">
+          <Link to={`/quiz/play/${quizId}`}>{quizTitle}</Link>
+        </h2>
         <p className="quiz-type">{getQuizTypeLabel(quizType)}</p>{" "}
         {/* 퀴즈 유형 표시 */}
         <p className="quiz-type">{subject || "과목"}</p> {/* 퀴즈 과목 표시 */}
       </div>
-
       <div className="quiz-info-container">
         <div className="quiz-stats">
           <p className="quiz-likes">👍 {likeCount}</p>

--- a/yuquiz/src/components/solveQuiz/MultipleChoose.jsx
+++ b/yuquiz/src/components/solveQuiz/MultipleChoose.jsx
@@ -1,24 +1,24 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { getQuiz } from "../../services/quiz/QuizManage";
 import "../../styles/quiztype/MultipleChoose.scss";
 
-export const MultipleChoose = () => {
+export const MultipleChoose = ({ quizID }) => {
+  const [quizData, setQuizData] = useState(null);
   const [selectedAnswers, setSelectedAnswers] = useState([]);
   const [score, setScore] = useState(0);
   const [currentQuestion, setCurrentQuestion] = useState(0);
 
-  const questions = [
-    {
-      title: "테스트 퀴즈입니당~",
-      question: "이중에서 정답은?",
-      quizImg: null,
-      quizType: "MULTIPLE_CHOICE",
-      likeCount: 0,
-      choices: ["1.뭐요", "2.뭘봐요", "3.아닌데", ""],
-      subject: "마이크로프로세서",
-      writer: "테스터입니다",
-      createdAt: "2024-08-10T16:33:00",
-    },
-  ];
+  useEffect(() => {
+    const fetchQuizData = async () => {
+      const data = await getQuiz(quizID);
+      setQuizData(data);
+    };
+    fetchQuizData();
+  }, [quizID]);
+
+  if (!quizData) {
+    return <div>로딩 중...</div>;
+  }
 
   const handleAnswerClick = (answer) => {
     setSelectedAnswers((prevAnswers) =>
@@ -29,7 +29,7 @@ export const MultipleChoose = () => {
   };
 
   const handleSubmit = () => {
-    const correctAnswers = questions[currentQuestion].correctAnswer;
+    const correctAnswers = quizData.questions[currentQuestion].correctAnswer;
     if (
       selectedAnswers.length === correctAnswers.length &&
       selectedAnswers.every((answer) => correctAnswers.includes(answer))
@@ -42,13 +42,15 @@ export const MultipleChoose = () => {
 
   return (
     <div className="quiz-container">
-      <h2 className="quiz-header">{questions[currentQuestion].title}</h2>
+      <h2 className="quiz-header">
+        {quizData.questions[currentQuestion].title}
+      </h2>
       <p className="quiz-question">
-        {currentQuestion + 1}/{questions.length}:{" "}
-        {questions[currentQuestion].question}
+        {currentQuestion + 1}/{quizData.questions.length}:{" "}
+        {quizData.questions[currentQuestion].question}
       </p>
       <div className="quiz-options">
-        {questions[currentQuestion].choices.map((choice, index) => (
+        {quizData.questions[currentQuestion].choices.map((choice, index) => (
           <div key={index} className="quiz-option">
             <input
               type="checkbox"

--- a/yuquiz/src/components/solveQuiz/MultipleChoose.jsx
+++ b/yuquiz/src/components/solveQuiz/MultipleChoose.jsx
@@ -5,8 +5,8 @@ import "../../styles/quiztype/MultipleChoose.scss";
 export const MultipleChoose = ({ quizID }) => {
   const [quizData, setQuizData] = useState(null);
   const [selectedAnswers, setSelectedAnswers] = useState([]);
-  const [score, setScore] = useState(0);
-  const [currentQuestion, setCurrentQuestion] = useState(0);
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [isCorrect, setIsCorrect] = useState(null);
 
   useEffect(() => {
     const fetchQuizData = async () => {
@@ -29,40 +29,56 @@ export const MultipleChoose = ({ quizID }) => {
   };
 
   const handleSubmit = () => {
-    const correctAnswers = quizData.questions[currentQuestion].correctAnswer;
     if (
-      selectedAnswers.length === correctAnswers.length &&
-      selectedAnswers.every((answer) => correctAnswers.includes(answer))
+      !quizData ||
+      !quizData.correctAnswer ||
+      !Array.isArray(quizData.correctAnswer)
     ) {
-      setScore(score + 1);
+      console.error("correctAnswer가 정의되지 않았거나 배열이 아닙니다.");
+      return;
     }
-    setSelectedAnswers([]);
-    setCurrentQuestion(currentQuestion + 1);
+
+    const correctAnswers = quizData.correctAnswer;
+
+    const isAllCorrect =
+      selectedAnswers.length === correctAnswers.length &&
+      selectedAnswers.every((answer) => correctAnswers.includes(answer));
+
+    setIsCorrect(isAllCorrect ? "맞았습니다!" : "틀렸습니다.");
+    setHasSubmitted(true);
   };
+
+  if (hasSubmitted) {
+    return (
+      <div className="quiz-container">
+        <h2>{quizData.title}</h2>
+        <p>{isCorrect}</p>
+        <button className="gotolist-button">목록으로</button>
+      </div>
+    );
+  }
 
   return (
     <div className="quiz-container">
-      <h2 className="quiz-header">
-        {quizData.questions[currentQuestion].title}
-      </h2>
-      <p className="quiz-question">
-        {currentQuestion + 1}/{quizData.questions.length}:{" "}
-        {quizData.questions[currentQuestion].question}
-      </p>
+      <p className="quiz-question">{quizData.question}</p>
       <div className="quiz-options">
-        {quizData.questions[currentQuestion].choices.map((choice, index) => (
-          <div key={index} className="quiz-option">
-            <input
-              type="checkbox"
-              id={`choice-${index}`}
-              name="quiz-choice"
-              value={choice}
-              checked={selectedAnswers.includes(choice)}
-              onChange={() => handleAnswerClick(choice)}
-            />
-            <label htmlFor={`choice-${index}`}>{choice}</label>
-          </div>
-        ))}
+        {quizData.choices.map(
+          (choice, index) =>
+            choice && (
+              <div key={index} className="quiz-option">
+                <input
+                  type="checkbox"
+                  className="choose-list"
+                  id={`choice-${index}`}
+                  name="quiz-choice"
+                  value={choice}
+                  checked={selectedAnswers.includes(choice)}
+                  onChange={() => handleAnswerClick(choice)}
+                />
+                <label htmlFor={`choice-${index}`}>{choice}</label>
+              </div>
+            )
+        )}
       </div>
       <div className="submit-box">
         <button

--- a/yuquiz/src/components/solveQuiz/OXQuiz.jsx
+++ b/yuquiz/src/components/solveQuiz/OXQuiz.jsx
@@ -1,33 +1,43 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { getQuiz } from "../../services/quiz/QuizManage";
 import "../../styles/quiztype/OXQuiz.scss";
-export const OXQuiz = () => {
+
+export const OXQuiz = ({ quizID }) => {
+  const [quizData, setQuizData] = useState(null);
   const [selectedAnswer, setSelectedAnswer] = useState(null);
   const [score, setScore] = useState(0);
   const [currentQuestion, setCurrentQuestion] = useState(0);
 
-  const questions = [
-    //나중엔 퀴즈 id로 받아와서 넣어줄거임
-    {
-      question: "한국의 수도는 대구이다?",
-    },
-  ];
+  useEffect(() => {
+    const fetchQuizData = async () => {
+      const data = await getQuiz(quizID);
+      setQuizData(data);
+    };
+    fetchQuizData();
+  }, [quizID]);
+
+  if (!quizData) {
+    return <div>로딩 중...</div>;
+  }
+
   const handleAnswerClick = (answer) => {
     setSelectedAnswer(answer);
   };
 
   const handleSubmit = () => {
-    if (selectedAnswer === questions[currentQuestion].correctAnswer) {
+    if (selectedAnswer === quizData.questions[currentQuestion].correctAnswer) {
       setScore(score + 1);
     }
     setSelectedAnswer(null);
     setCurrentQuestion(currentQuestion + 1);
   };
+
   return (
     <div className="quiz-container">
       <h2 className="quiz-header">O/X Quiz</h2>
       <p className="quiz-question">
-        {currentQuestion + 1}/{questions.length}:{" "}
-        {questions[currentQuestion].question}
+        {currentQuestion + 1}/{quizData.questions.length}:{" "}
+        {quizData.questions[currentQuestion].question}
       </p>
       <div className="quiz-options">
         <button onClick={() => handleAnswerClick("true")}>O</button>

--- a/yuquiz/src/components/solveQuiz/OXQuiz.jsx
+++ b/yuquiz/src/components/solveQuiz/OXQuiz.jsx
@@ -6,7 +6,8 @@ export const OXQuiz = ({ quizID }) => {
   const [quizData, setQuizData] = useState(null);
   const [selectedAnswer, setSelectedAnswer] = useState(null);
   const [score, setScore] = useState(0);
-  const [currentQuestion, setCurrentQuestion] = useState(0);
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [IsCorrect, setIsCorrect] = useState("맞았습니다.");
 
   useEffect(() => {
     const fetchQuizData = async () => {
@@ -16,32 +17,50 @@ export const OXQuiz = ({ quizID }) => {
     fetchQuizData();
   }, [quizID]);
 
+  // 로딩 중 처리
   if (!quizData) {
     return <div>로딩 중...</div>;
   }
 
+  // 답안 선택 처리
   const handleAnswerClick = (answer) => {
     setSelectedAnswer(answer);
   };
 
+  // 제출 처리
   const handleSubmit = () => {
-    if (selectedAnswer === quizData.questions[currentQuestion].correctAnswer) {
-      setScore(score + 1);
+    if (selectedAnswer === quizData.choices[0]) {
+      setScore(1);
+    } else {
+      setScore(0);
     }
-    setSelectedAnswer(null);
-    setCurrentQuestion(currentQuestion + 1);
+    setHasSubmitted(true); // 제출 후 버튼 비활성화
   };
+
+  // 제출 후 메시지 처리
+  if (hasSubmitted) {
+    if (score === 0) {
+      setIsCorrect("틀렸습니다.");
+    }
+    return (
+      <div className="quiz-container">
+        <h2>퀴즈가 완료되었습니다!</h2>
+        <p>{IsCorrect}</p>
+        <button className="gotolist-button">목록으로</button>
+      </div>
+    );
+  }
 
   return (
     <div className="quiz-container">
-      <h2 className="quiz-header">O/X Quiz</h2>
-      <p className="quiz-question">
-        {currentQuestion + 1}/{quizData.questions.length}:{" "}
-        {quizData.questions[currentQuestion].question}
-      </p>
+      <p className="quiz-question">{quizData.question}</p>
       <div className="quiz-options">
-        <button onClick={() => handleAnswerClick("true")}>O</button>
-        <button onClick={() => handleAnswerClick("false")}>X</button>
+        <button onClick={() => handleAnswerClick(quizData.choices[0])}>
+          O
+        </button>
+        <button onClick={() => handleAnswerClick(quizData.choices[1])}>
+          X
+        </button>
       </div>
       <div className="submit-box">
         <button

--- a/yuquiz/src/components/solveQuiz/ShortAnswer.jsx
+++ b/yuquiz/src/components/solveQuiz/ShortAnswer.jsx
@@ -1,48 +1,53 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import { getQuiz } from "../../services/quiz/QuizManage";
 import "../../styles/quiztype/ShortAnswer.scss";
-export const ShortAnswer = () => {
+
+export const ShortAnswer = ({ quizID }) => {
+  const [quizData, setQuizData] = useState(null);
   const [writtenAnswer, setWrittenAnswer] = useState("");
   const [score, setScore] = useState(0);
   const [currentQuestion, setCurrentQuestion] = useState(0);
 
-  const questions = [
-    //나중엔 퀴즈 id로 받아와서 넣어줄거임
-    {
-      title: "초간단 퀴즈입니당~",
-      question: "내 이름은?",
-      quizImg: null,
-      quizType: "ShortAnswer",
-      likeCount: 0,
-      choices: null,
-      subject: "관리자",
-      writer: "테스터입니다",
-      createdAt: "2024-08-10T16:33:00",
-    },
-  ];
-  const handleInputAnswer = (answer) => {
-    setWrittenAnswer(answer);
+  useEffect(() => {
+    const fetchQuizData = async () => {
+      const data = await getQuiz(quizID);
+      setQuizData(data);
+    };
+    fetchQuizData();
+  }, [quizID]);
+
+  if (!quizData) {
+    return <div>로딩 중...</div>;
+  }
+
+  const handleInputAnswer = (e) => {
+    setWrittenAnswer(e.target.value);
   };
 
   const handleSubmit = () => {
-    if (writtenAnswer === questions[currentQuestion].correctAnswer) {
+    if (writtenAnswer === quizData.questions[currentQuestion].correctAnswer) {
       setScore(score + 1);
     }
     setWrittenAnswer("");
     setCurrentQuestion(currentQuestion + 1);
   };
+
   return (
     <div className="quiz-container">
-      <h2 className="quiz-header">{questions[currentQuestion].title}</h2>
+      <h2 className="quiz-header">
+        {quizData.questions[currentQuestion].title}
+      </h2>
       <p className="quiz-question">
-        {currentQuestion + 1}/{questions.length}:{" "}
-        {questions[currentQuestion].question}
+        {currentQuestion + 1}/{quizData.questions.length}:{" "}
+        {quizData.questions[currentQuestion].question}
       </p>
       <div className="quiz-options">
         <input
           type="text"
           className="input-box"
           onChange={handleInputAnswer}
-        ></input>
+          value={writtenAnswer}
+        />
       </div>
       <div className="submit-box">
         <button

--- a/yuquiz/src/components/solveQuiz/ShortAnswer.jsx
+++ b/yuquiz/src/components/solveQuiz/ShortAnswer.jsx
@@ -5,8 +5,8 @@ import "../../styles/quiztype/ShortAnswer.scss";
 export const ShortAnswer = ({ quizID }) => {
   const [quizData, setQuizData] = useState(null);
   const [writtenAnswer, setWrittenAnswer] = useState("");
-  const [score, setScore] = useState(0);
-  const [currentQuestion, setCurrentQuestion] = useState(0);
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [isCorrect, setIsCorrect] = useState(null);
 
   useEffect(() => {
     const fetchQuizData = async () => {
@@ -25,22 +25,24 @@ export const ShortAnswer = ({ quizID }) => {
   };
 
   const handleSubmit = () => {
-    if (writtenAnswer === quizData.questions[currentQuestion].correctAnswer) {
-      setScore(score + 1);
-    }
-    setWrittenAnswer("");
-    setCurrentQuestion(currentQuestion + 1);
+    const isAnswerCorrect = writtenAnswer === quizData.correctAnswer;
+    setIsCorrect(isAnswerCorrect ? "맞았습니다!" : "틀렸습니다.");
+    setHasSubmitted(true);
   };
+
+  if (hasSubmitted) {
+    return (
+      <div className="quiz-container">
+        <h2>{quizData.question}</h2>
+        <p>{isCorrect}</p>
+        <button className="gotolist-button">목록으로</button>
+      </div>
+    );
+  }
 
   return (
     <div className="quiz-container">
-      <h2 className="quiz-header">
-        {quizData.questions[currentQuestion].title}
-      </h2>
-      <p className="quiz-question">
-        {currentQuestion + 1}/{quizData.questions.length}:{" "}
-        {quizData.questions[currentQuestion].question}
-      </p>
+      <p className="quiz-question">{quizData.question}</p>
       <div className="quiz-options">
         <input
           type="text"

--- a/yuquiz/src/pages/quiz/QuizFix.jsx
+++ b/yuquiz/src/pages/quiz/QuizFix.jsx
@@ -1,69 +1,57 @@
 import React, { useState, useEffect, useRef } from "react";
 import { IoMdArrowBack } from "react-icons/io";
 import "../../styles/quiz/QuizFix.scss";
-import { Link } from "react-router-dom";
+import { Link, useParams, useNavigate } from "react-router-dom";
+import { getQuiz } from "../../services/quiz/QuizManage";
+import { fixQuiz } from "../../services/quiz/QuizManage";
 
 export const QuizFix = () => {
+  const { quizId } = useParams(); // URL에서 quizId 가져옴
+  const navigate = useNavigate();
   const [questionTitle, setQuestionTitle] = useState("");
   const [questionContent, setQuestionContent] = useState("");
   const [questionType, setQuestionType] = useState("");
   const [answers, setAnswers] = useState([]);
   const [image, setImage] = useState(null);
+  const [loading, setLoading] = useState(true); // 로딩 상태 추가
   const textAreaRef = useRef(null);
 
-  // 예제 퀴즈 데이터
-  const questions = {
-    title: "알고리즘 문제",
-    question: "퀵정렬 알고리즘의 시간복잡도는?",
-    quizImg: "?",
-    answer: "2",
-    quizType: "MULTIPLE_CHOICE", // 유형
-    choices: ["1.O(N)", "2.O(N^2)", "3.O(NlogN)"],
-    subjectId: 2,
-  };
-
-  // 유형 텍스트
-  const getQuizTypeLabel = (quizType) => {
-    switch (quizType) {
-      case "MULTIPLE_CHOICE":
-        return "객관식";
-      case "TRUE_FALSE":
-        return "O/X";
-      case "SHORT_ANSWER":
-        return "단답식";
-      default:
-        return "알 수 없음";
-    }
-  };
-
-  // 기존 데이터를 로드하여 상태 설정
   useEffect(() => {
-    const quiz = questions;
+    // 초기 데이터 로드
+    const fetchQuizData = async () => {
+      try {
+        const quiz = await getQuiz(quizId);
+        setQuestionTitle(quiz.title);
+        setQuestionContent(quiz.question);
+        setQuestionType(quiz.quizType);
 
-    setQuestionTitle(quiz.title);
-    setQuestionContent(quiz.question);
-    setQuestionType(quiz.quizType);
+        if (quiz.quizType === "MULTIPLE_CHOICE") {
+          setAnswers(
+            quiz.choices.map((choice, index) => ({
+              num: index + 1,
+              text: choice,
+              correct: quiz.answer === `${index + 1}`,
+            }))
+          );
+        } else if (quiz.quizType === "TRUE_FALSE") {
+          setAnswers([
+            { num: 1, text: "True", correct: quiz.answer === "True" },
+            { num: 2, text: "False", correct: quiz.answer === "False" },
+          ]);
+        } else if (quiz.quizType === "SHORT_ANSWER") {
+          setAnswers([{ num: 1, text: quiz.answer, correct: true }]);
+        }
 
-    // 유형에 따라 answers 상태를 설정
-    if (quiz.quizType === "MULTIPLE_CHOICE") {
-      setAnswers(
-        quiz.choices.map((choice, index) => ({
-          num: index + 1,
-          text: choice,
-          correct: quiz.answer === `${index + 1}`, // 정답을 표시
-        }))
-      );
-    } else if (quiz.quizType === "TRUE_FALSE") {
-      setAnswers([
-        { num: 1, text: "True", correct: quiz.answer === "True" },
-        { num: 2, text: "False", correct: quiz.answer === "False" },
-      ]);
-    } else if (quiz.quizType === "SHORT_ANSWER") {
-      setAnswers([{ num: 1, text: quiz.answer, correct: true }]);
-    }
+        setImage(quiz.quizImg); // 이미지 설정
+      } catch (error) {
+        console.error("퀴즈 데이터를 불러오는 중 에러 발생:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
 
-    setImage(quiz.quizImg); // 이미지 설정
-  }, []);
+    fetchQuizData();
+  }, [quizId]);
 
   const handleAnswerChange = (index, field, value) => {
     const newAnswers = [...answers];
@@ -71,31 +59,50 @@ export const QuizFix = () => {
     setAnswers(newAnswers);
   };
 
-  const handleSubmitQuiz = () => {
-    // 퀴즈 데이터를 서버로 제출하는 로직
-    const updatedQuiz = {
-      title: questionTitle,
-      question: questionContent,
-      quizType: questionType,
-      choices:
-        questionType === "MULTIPLE_CHOICE" || questionType === "TRUE_FALSE"
-          ? answers.map((answer) => answer.text)
-          : [],
-      answer:
-        questionType === "MULTIPLE_CHOICE" || questionType === "TRUE_FALSE"
-          ? answers.find((answer) => answer.correct)?.text || ""
-          : answers[0].text,
-      quizImg: image,
-      // 기타 필요한 데이터 추가
-    };
+  const handleSubmitQuiz = async () => {
+    try {
+      // 퀴즈 데이터를 서버로 제출하는 로직
+      const updatedQuiz = {
+        quizId, // 수정 중인 퀴즈의 ID
+        title: questionTitle,
+        question: questionContent,
+        quizType: questionType,
+        choices:
+          questionType === "MULTIPLE_CHOICE" || questionType === "TRUE_FALSE"
+            ? answers.map((answer) => answer.text)
+            : [],
+        answer:
+          questionType === "MULTIPLE_CHOICE" || questionType === "TRUE_FALSE"
+            ? answers.find((answer) => answer.correct)?.text || ""
+            : answers[0].text,
+        quizImg: image,
+        subjectId: 2,
+      };
 
-    console.log("Updated Quiz:", updatedQuiz);
-    // 여기서 updatedQuiz를 서버로 보내는 API 호출을 하면 됩니다.
+      // fixQuiz API 호출로 데이터 전송
+      const wellDone = await fixQuiz(updatedQuiz);
+      if (wellDone) {
+        console.log("Updated Quiz:", updatedQuiz);
+        alert("수정 성공");
+        // 퀴즈 목록 페이지로 이동
+        navigate(`/quiz/play/${updatedQuiz.quizId}`);
+      } else {
+        alert("다시 시도해주세요. ");
+      }
+    } catch (error) {
+      console.error("퀴즈 수정 중 오류 발생:", error);
+    }
   };
+
+  if (loading) {
+    return <div>로딩 중...</div>;
+  }
 
   return (
     <div>
-      <Link to='/quiz/list' className="back-button"><IoMdArrowBack /></Link>
+      <Link to="/quiz/list" className="back-button">
+        <IoMdArrowBack />
+      </Link>
       <div className="container">
         <div className="quiz-creator">
           <h2 className="title">Quiz 수정</h2>
@@ -118,14 +125,8 @@ export const QuizFix = () => {
 
           <div className="form-group">
             <label>Quiz 유형(유형은 수정❌)</label>
-            <select
-              value={questionType}
-              onChange={(e) => setQuestionType(e.target.value)}
-              disabled
-            >
-              <option value={questions.quizType}>
-                {getQuizTypeLabel(questions.quizType)}
-              </option>
+            <select value={questionType} disabled>
+              <option value={questionType}>{questionType}</option>
             </select>
           </div>
 
@@ -208,4 +209,4 @@ export const QuizFix = () => {
       </div>
     </div>
   );
-}
+};

--- a/yuquiz/src/pages/quiz/QuizListPage.jsx
+++ b/yuquiz/src/pages/quiz/QuizListPage.jsx
@@ -1,5 +1,4 @@
 // src/pages/QuizListPage.jsx
-
 import React, { useState, useEffect } from "react";
 import "../../styles/quiz_list_page/QuizListPage.scss";
 import QuizList from "../../components/quizlist/QuizList";

--- a/yuquiz/src/pages/quiz/QuizSolve.jsx
+++ b/yuquiz/src/pages/quiz/QuizSolve.jsx
@@ -51,10 +51,15 @@ export const QuizSolve = () => {
   // 드롭다운 메뉴 렌더링 함수
   const renderDropdownMenu = () => (
     <div className="dropdown-menu">
-      <button className="dropdown-item">좋아요</button>
-      <button className="dropdown-item">즐겨찾기</button>
-      <button className="dropdown-item">신고하기</button>
-      {quizData.isWriter && <button className="dropdown-item">삭제하기</button>}
+      <button className="dropdown-item">👍좋아요</button>
+      <button className="dropdown-item">⭐즐겨찾기</button>
+      <button className="dropdown-item">🚨신고하기</button>
+      {quizData.isWriter && (
+        <button className="dropdown-item">📝수정하기</button>
+      )}
+      {quizData.isWriter && (
+        <button className="dropdown-item">🗑️삭제하기</button>
+      )}
     </div>
   );
 

--- a/yuquiz/src/pages/quiz/QuizSolve.jsx
+++ b/yuquiz/src/pages/quiz/QuizSolve.jsx
@@ -1,16 +1,18 @@
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom"; // useParams로 URL에서 quizId 가져오기
+import { Link, useNavigate, useParams } from "react-router-dom"; // useParams로 URL에서 quizId 가져오기
 import { getQuiz } from "../../services/quiz/QuizManage";
 import "../../styles/quiz/QuizSolve.scss";
 import { MultipleChoose } from "../../components/solveQuiz/MultipleChoose";
 import { OXQuiz } from "../../components/solveQuiz/OXQuiz";
 import { ShortAnswer } from "../../components/solveQuiz/ShortAnswer";
+import { IoMdArrowBack } from "react-icons/io";
 
 export const QuizSolve = () => {
   const { quizId } = useParams(); // URL에서 quizId를 가져옴
   const [quizData, setQuizData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const navigate = useNavigate(); // 네비게이트 함수만 가져옴
 
   useEffect(() => {
     const fetchQuizData = async () => {
@@ -41,7 +43,7 @@ export const QuizSolve = () => {
 
   // 퀴즈 타입에 따라 다른 컴포넌트를 렌더링
   const renderQuizComponent = () => {
-    switch (quizData.type) {
+    switch (quizData.quizType) {
       case "MULTIPLE_CHOICE":
         return <MultipleChoose quizID={quizId} />;
       case "TRUE_FALSE":
@@ -54,9 +56,13 @@ export const QuizSolve = () => {
   };
 
   return (
-    <div className="quiz-solve-page">
-      <h1>{quizData.title}</h1>
-      {renderQuizComponent()}
+    <div className="quiz-body">
+      {/* 버튼 클릭 시 navigate(-1) 실행 */}
+      <IoMdArrowBack className="back-button" onClick={() => navigate(-1)} />
+      <div className="quiz-solve-page">
+        <h1>{quizData.title}</h1>
+        {renderQuizComponent()}
+      </div>
     </div>
   );
 };

--- a/yuquiz/src/pages/quiz/QuizSolve.jsx
+++ b/yuquiz/src/pages/quiz/QuizSolve.jsx
@@ -55,7 +55,9 @@ export const QuizSolve = () => {
       <button className="dropdown-item">⭐즐겨찾기</button>
       <button className="dropdown-item">🚨신고하기</button>
       {quizData.isWriter && (
-        <button className="dropdown-item">📝수정하기</button>
+        <Link to={`/quiz/edit/${quizId}`} className="dropdown-link">
+          📝수정하기
+        </Link>
       )}
       {quizData.isWriter && (
         <button className="dropdown-item">🗑️삭제하기</button>

--- a/yuquiz/src/pages/quiz/QuizSolve.jsx
+++ b/yuquiz/src/pages/quiz/QuizSolve.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom"; // useParams로 URL에서 quizId 가져오기
-import { getQuiz } from "../../services/quiz/QuizManage";
+import { deleteQuiz, getQuiz } from "../../services/quiz/QuizManage";
 import "../../styles/quiz/QuizSolve.scss";
 import { MultipleChoose } from "../../components/solveQuiz/MultipleChoose";
 import { OXQuiz } from "../../components/solveQuiz/OXQuiz";
@@ -47,6 +47,12 @@ export const QuizSolve = () => {
   const handleDropdownToggle = () => {
     setIsDropdownOpen(!isDropdownOpen);
   };
+  const handleDelete = async () => {
+    const wellDone = await deleteQuiz(quizId);
+    if (wellDone) {
+      navigate(-1);
+    }
+  };
 
   // 드롭다운 메뉴 렌더링 함수
   const renderDropdownMenu = () => (
@@ -60,7 +66,9 @@ export const QuizSolve = () => {
         </Link>
       )}
       {quizData.isWriter && (
-        <button className="dropdown-item">🗑️삭제하기</button>
+        <button className="dropdown-item" onClick={handleDelete}>
+          🗑️삭제하기
+        </button>
       )}
     </div>
   );

--- a/yuquiz/src/pages/quiz/QuizSolve.jsx
+++ b/yuquiz/src/pages/quiz/QuizSolve.jsx
@@ -6,12 +6,14 @@ import { MultipleChoose } from "../../components/solveQuiz/MultipleChoose";
 import { OXQuiz } from "../../components/solveQuiz/OXQuiz";
 import { ShortAnswer } from "../../components/solveQuiz/ShortAnswer";
 import { IoMdArrowBack } from "react-icons/io";
+import { IoEllipsisVertical } from "react-icons/io5";
 
 export const QuizSolve = () => {
   const { quizId } = useParams(); // URL에서 quizId를 가져옴
   const [quizData, setQuizData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false); // 드롭다운 상태 추가
   const navigate = useNavigate(); // 네비게이트 함수만 가져옴
 
   useEffect(() => {
@@ -41,6 +43,21 @@ export const QuizSolve = () => {
     return <div>퀴즈 데이터를 찾을 수 없습니다.</div>;
   }
 
+  // 드롭다운 상태 핸들링 함수
+  const handleDropdownToggle = () => {
+    setIsDropdownOpen(!isDropdownOpen);
+  };
+
+  // 드롭다운 메뉴 렌더링 함수
+  const renderDropdownMenu = () => (
+    <div className="dropdown-menu">
+      <button className="dropdown-item">좋아요</button>
+      <button className="dropdown-item">즐겨찾기</button>
+      <button className="dropdown-item">신고하기</button>
+      {quizData.isWriter && <button className="dropdown-item">삭제하기</button>}
+    </div>
+  );
+
   // 퀴즈 타입에 따라 다른 컴포넌트를 렌더링
   const renderQuizComponent = () => {
     switch (quizData.quizType) {
@@ -59,6 +76,16 @@ export const QuizSolve = () => {
     <div className="quiz-body">
       {/* 버튼 클릭 시 navigate(-1) 실행 */}
       <IoMdArrowBack className="back-button" onClick={() => navigate(-1)} />
+
+      {/* 설정 버튼 클릭 시 드롭다운 메뉴 토글 */}
+      <div className="dropdown-container">
+        <IoEllipsisVertical
+          className="setting-button"
+          onClick={handleDropdownToggle}
+        />
+        {isDropdownOpen && renderDropdownMenu()}
+      </div>
+
       <div className="quiz-solve-page">
         <h1>{quizData.title}</h1>
         {renderQuizComponent()}

--- a/yuquiz/src/pages/quiz/QuizSolve.jsx
+++ b/yuquiz/src/pages/quiz/QuizSolve.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom"; // useParams로 URL에서 quizId 가져오기
+import { getQuiz } from "../../services/quiz/QuizManage";
+import "../../styles/quiz/QuizSolve.scss";
+import { MultipleChoose } from "../../components/solveQuiz/MultipleChoose";
+import { OXQuiz } from "../../components/solveQuiz/OXQuiz";
+import { ShortAnswer } from "../../components/solveQuiz/ShortAnswer";
+
+export const QuizSolve = () => {
+  const { quizId } = useParams(); // URL에서 quizId를 가져옴
+  const [quizData, setQuizData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchQuizData = async () => {
+      try {
+        const data = await getQuiz(quizId); // quizId를 사용하여 API 호출
+        setQuizData(data);
+      } catch (error) {
+        setError(error.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchQuizData();
+  }, [quizId]); // quizId가 변경될 때마다 호출
+
+  if (loading) {
+    return <div>로딩 중...</div>;
+  }
+
+  if (error) {
+    return <div>에러 발생: {error}</div>;
+  }
+
+  if (!quizData) {
+    return <div>퀴즈 데이터를 찾을 수 없습니다.</div>;
+  }
+
+  // 퀴즈 타입에 따라 다른 컴포넌트를 렌더링
+  const renderQuizComponent = () => {
+    switch (quizData.type) {
+      case "MULTIPLE_CHOICE":
+        return <MultipleChoose quizID={quizId} />;
+      case "TRUE_FALSE":
+        return <OXQuiz quizID={quizId} />;
+      case "SHORT_ANSWER":
+        return <ShortAnswer quizID={quizId} />;
+      default:
+        return <div>지원되지 않는 퀴즈 유형입니다.</div>;
+    }
+  };
+
+  return (
+    <div className="quiz-solve-page">
+      <h1>{quizData.title}</h1>
+      {renderQuizComponent()}
+    </div>
+  );
+};

--- a/yuquiz/src/routes/router.jsx
+++ b/yuquiz/src/routes/router.jsx
@@ -1,17 +1,19 @@
+// src/router/index.js
 import { createBrowserRouter, Outlet } from "react-router-dom";
 import Root from "../pages/Root";
-import EditProfile from "../pages/mypage/EditProfile";
 import QuizListPage from "../pages/quiz/QuizListPage";
-import PostListPage from "../pages/post/PostListPage";
-import { Login } from "../pages/login/Login";
-import { Register } from "../pages/register/Register";
-import MyPage from "../pages/mypage/MyPage";
+import { QuizSolve } from "../pages/quiz/QuizSolve"; // 퀴즈 풀기 컴포넌트 추가
 import { QuizCreator } from "../pages/quiz/QuizCreator";
 import { QuizFix } from "../pages/quiz/QuizFix";
+import MyPageLayout from "../pages/mypage/MyPageLayout";
+import MyPage from "../pages/mypage/MyPage";
+import EditProfile from "../pages/mypage/EditProfile";
+import { Login } from "../pages/login/Login";
+import { Register } from "../pages/register/Register";
+import PostListPage from "../pages/post/PostListPage";
 import PostCreator from "../pages/post/PostCreator";
 import PostFix from "../pages/post/PostFix";
 import PostView from "../pages/post/PostView";
-import MyPageLayout from "../pages/mypage/MyPageLayout";
 
 const router = createBrowserRouter([
   {
@@ -32,11 +34,11 @@ const router = createBrowserRouter([
       },
       {
         path: "register",
-        element: <Register />, // 회원가입 컴포넌트
+        element: <Register />,
       },
       {
         path: "my",
-        element: <MyPageLayout />, // 마이페이지 컴포넌트
+        element: <MyPageLayout />,
         children: [
           {
             index: true,
@@ -44,7 +46,7 @@ const router = createBrowserRouter([
           },
           {
             path: "edit",
-            element: <EditProfile />, // 정보 수정하기 컴포넌트
+            element: <EditProfile />,
           },
         ],
       },
@@ -58,19 +60,20 @@ const router = createBrowserRouter([
         children: [
           {
             path: "list",
-            element: <QuizListPage />, // 퀴즈 목록 컴포넌트
+            element: <QuizListPage />,
           },
           {
             path: "create",
-            element: <QuizCreator />, // 퀴즈 생성 컴포넌트
+            element: <QuizCreator />,
           },
           {
             path: "edit/:quizId",
-            element: <QuizFix />, // 퀴즈 수정 컴포넌트 (동적 경로)
+            element: <QuizFix />,
           },
           {
+            // 퀴즈 풀기 페이지 라우트 추가
             path: "play/:quizId",
-            element: <QuizFix />, // 퀴즈 풀기 컴포넌트 (동적 경로)
+            element: <QuizSolve />, // 퀴즈 풀기 컴포넌트 연결
           },
         ],
       },
@@ -84,25 +87,25 @@ const router = createBrowserRouter([
         children: [
           {
             path: "list",
-            element: <PostListPage />, // 게시글 목록 컴포넌트
+            element: <PostListPage />,
           },
           {
             path: "create",
-            element: <PostCreator />, // 게시글 생성 컴포넌트
+            element: <PostCreator />,
           },
           {
             path: "edit/:postId",
-            element: <PostFix />, // 게시글 수정 컴포넌트 (동적 경로)
+            element: <PostFix />,
           },
           {
             path: "view/:postId",
-            element: <PostView />, // 게시글 조회 컴포넌트 (동적 경로)
+            element: <PostView />,
           },
         ],
       },
       {
         path: "admin",
-        element: <MyPageLayout />, // 관리자 페이지 컴포넌트
+        element: <MyPageLayout />,
         children: [
           {
             index: true,

--- a/yuquiz/src/services/quiz/QuizManage.js
+++ b/yuquiz/src/services/quiz/QuizManage.js
@@ -44,4 +44,19 @@ const getQuizList = async (
   }
 };
 
-export { getQuizList, SORT_OPTIONS };
+const getQuiz = async (quizID) => {
+  try {
+    // API 호출
+    const response = await api.get(`${SERVER_API}/quizzes/${quizID}`);
+    console.log(response.data);
+
+    return response.data;
+  } catch (error) {
+    if (error.response) {
+      throw new Error("퀴즈가 존재하지 않습니다.");
+    } else {
+      throw new Error("서버와 연결할 수 없습니다.");
+    }
+  }
+};
+export { getQuizList, SORT_OPTIONS, getQuiz };

--- a/yuquiz/src/services/quiz/QuizManage.js
+++ b/yuquiz/src/services/quiz/QuizManage.js
@@ -1,3 +1,4 @@
+import { HttpStatusCode } from "axios";
 import api from "../apiService";
 const SERVER_API = process.env.REACT_APP_YUQUIZ;
 
@@ -74,4 +75,19 @@ const fixQuiz = async (quizData) => {
     }
   }
 };
-export { getQuizList, SORT_OPTIONS, getQuiz, fixQuiz };
+const deleteQuiz = async (quizId) => {
+  try {
+    const response = await api.delete(`${SERVER_API}/quizzes/${quizId}`);
+    if (response.status === HttpStatusCode.NoContent) {
+      alert("삭제 성공");
+    }
+    return response;
+  } catch (error) {
+    if (error.response) {
+      throw new Error("퀴즈 삭제 중 문제가 발생했습니다. 다시 시도해주세요.");
+    } else {
+      throw new Error("서버와 연결할 수 없습니다.");
+    }
+  }
+};
+export { getQuizList, SORT_OPTIONS, getQuiz, fixQuiz, deleteQuiz };

--- a/yuquiz/src/services/quiz/QuizManage.js
+++ b/yuquiz/src/services/quiz/QuizManage.js
@@ -59,4 +59,19 @@ const getQuiz = async (quizID) => {
     }
   }
 };
-export { getQuizList, SORT_OPTIONS, getQuiz };
+const fixQuiz = async (quizData) => {
+  try {
+    const response = await api.put(
+      `${SERVER_API}/quizzes/${quizData.quizId}`,
+      quizData
+    );
+    return response;
+  } catch (error) {
+    if (error.response) {
+      throw new Error("퀴즈 수정 중 문제가 발생했습니다. 다시 시도해주세요.");
+    } else {
+      throw new Error("서버와 연결할 수 없습니다.");
+    }
+  }
+};
+export { getQuizList, SORT_OPTIONS, getQuiz, fixQuiz };

--- a/yuquiz/src/styles/quiz/QuizSolve.scss
+++ b/yuquiz/src/styles/quiz/QuizSolve.scss
@@ -1,35 +1,86 @@
 .quiz-body {
-    display: flex;
-    justify-content: center;  // 수직 중앙 정렬
-    align-items: center;      // 수평 중앙 정렬
-    width: 100%;
-    height: 100vh;  // 화면 전체 높이 사용
-    .back-button {
-        position: absolute; /* 버튼을 절대 위치로 설정 */
-        top: 20px; /* 상단에서 20px 아래 */
-        left: 20px; /* 좌측에서 20px 오른쪽 */
-        background: none;
-        border: none;
-        font-size: 50px;
-        cursor: pointer;
-        &:hover{
-            background-color: silver;
-            border-radius: 20px;
-        }
+  display: flex;
+  justify-content: center; // 수직 중앙 정렬
+  align-items: center; // 수평 중앙 정렬
+  width: 100%;
+  height: 100vh; // 화면 전체 높이 사용
+
+  .back-button {
+    position: absolute; /* 버튼을 절대 위치로 설정 */
+    top: 20px; /* 상단에서 20px 아래 */
+    left: 20px; /* 좌측에서 20px 오른쪽 */
+    background: none;
+    border: none;
+    font-size: 50px;
+    cursor: pointer;
+    &:hover {
+      background-color: silver;
+      border-radius: 20px;
     }
-    .quiz-solve-page {
+  }
+
+  
+
+  .dropdown-container {
+    position: absolute; /* 드롭다운 메뉴를 버튼 아래에 표시 */
+    top: 20px; /* 설정 버튼 아래로 60px 위치 */
+    right: 0; /* 우측 정렬 */
+    .setting-button {
+      background: none;
+      border: none;
+      font-size: 50px;
+      cursor: pointer;
+      &:hover {
+        background-color: silver;
+        border-radius: 20px;
+      }
+    }
+    .dropdown-menu {
+      background-color: #fff; /* 흰색 배경 */
+      border: 1px solid #ddd; /* 경계선 */
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15); /* 그림자 효과 */
+      border-radius: 8px; /* 모서리 둥글게 */
+      overflow: hidden; /* 내부 요소가 넘치지 않도록 */
+      z-index: 1000; /* 다른 요소 위에 표시 */
+      min-width: 150px; /* 최소 너비 설정 */
       display: flex;
-      flex-direction: column;
-      align-items: center;
-      width: 100%;
-      height: 70vh;
-      max-width: 600px; // 최대 너비 설정
-      padding: 20px;
-      h1 {
-        font-size: 2rem;
-        margin-bottom: 20px;
-        color: #333;
+      flex-direction: column; /* 세로 정렬 */
+      .dropdown-item {
+        padding: 10px 15px; /* 내부 여백 설정 */
+        cursor: pointer; /* 클릭 가능하게 커서 변경 */
+        font-size: 16px; /* 폰트 크기 */
+        color: #333; /* 텍스트 색상 */
+        background-color: #fff; /* 배경 흰색 */
+        border-bottom: 1px solid #ddd; /* 항목 사이에 경계선 추가 */
+        
+        &:hover {
+          background-color: #f2f2f2; /* 마우스 오버 시 배경 색상 변경 */
+        }
+    
+        &:last-child {
+          border-bottom: none; /* 마지막 항목의 경계선 제거 */
+        }
       }
     }
   }
+
   
+
+  
+
+  .quiz-solve-page {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    height: 70vh;
+    max-width: 600px; // 최대 너비 설정
+    padding: 20px;
+
+    h1 {
+      font-size: 2rem;
+      margin-bottom: 20px;
+      color: #333;
+    }
+  }
+}

--- a/yuquiz/src/styles/quiz/QuizSolve.scss
+++ b/yuquiz/src/styles/quiz/QuizSolve.scss
@@ -1,0 +1,35 @@
+.quiz-body {
+    display: flex;
+    justify-content: center;  // 수직 중앙 정렬
+    align-items: center;      // 수평 중앙 정렬
+    width: 100%;
+    height: 100vh;  // 화면 전체 높이 사용
+    .back-button {
+        position: absolute; /* 버튼을 절대 위치로 설정 */
+        top: 20px; /* 상단에서 20px 아래 */
+        left: 20px; /* 좌측에서 20px 오른쪽 */
+        background: none;
+        border: none;
+        font-size: 50px;
+        cursor: pointer;
+        &:hover{
+            background-color: silver;
+            border-radius: 20px;
+        }
+    }
+    .quiz-solve-page {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      width: 100%;
+      height: 70vh;
+      max-width: 600px; // 최대 너비 설정
+      padding: 20px;
+      h1 {
+        font-size: 2rem;
+        margin-bottom: 20px;
+        color: #333;
+      }
+    }
+  }
+  

--- a/yuquiz/src/styles/quiz/QuizSolve.scss
+++ b/yuquiz/src/styles/quiz/QuizSolve.scss
@@ -52,17 +52,23 @@
       flex-direction: column; /* 세로 정렬 */
     }
 
-    .dropdown-item {
-      padding: 10px 15px; /* 내부 여백 설정 */
-      cursor: pointer; /* 클릭 가능하게 커서 변경 */
-      font-size: 16px; /* 폰트 크기 */
-      color: #333; /* 텍스트 색상 */
-      background-color: #fff; /* 배경 흰색 */
-      border-bottom: 1px solid #ddd; /* 항목 사이에 경계선 추가 */
-      
+    .dropdown-item,
+    .dropdown-link {
+      padding: 10px 15px;
+      font-size: 16px;
+      cursor: pointer;
+      text-align: left; // 좌측 정렬
+      border: none;
+      background: none;
+      color: #333;
+      text-decoration: none; // 밑줄 제거
+      display: block; // 전체 영역 클릭 가능하게 설정
+      width: 100%; // 전체 너비 사용
       &:hover {
-        background-color: #f2f2f2; /* 마우스 오버 시 배경 색상 변경 */
+        background-color: #f2f2f2; // Hover 효과
       }
+    }
+  
 
     }
   }
@@ -82,4 +88,4 @@
       color: #333;
     }
   }
-}
+

--- a/yuquiz/src/styles/quiz/QuizSolve.scss
+++ b/yuquiz/src/styles/quiz/QuizSolve.scss
@@ -19,12 +19,14 @@
     }
   }
 
-  
-
+  // 설정 버튼과 드롭다운 메뉴를 감싸는 컨테이너
   .dropdown-container {
-    position: absolute; /* 드롭다운 메뉴를 버튼 아래에 표시 */
-    top: 20px; /* 설정 버튼 아래로 60px 위치 */
-    right: 0; /* 우측 정렬 */
+    position: absolute; /* 절대 위치로 설정하여 quiz-body 내 고정 */
+    top: 20px; /* 상단에서 20px 아래 */
+    right: 20px; /* 우측에서 20px 왼쪽 */
+    display: flex; /* 컨테이너 내 요소 수평 정렬 */
+    align-items: center; /* 버튼을 수직 정렬 */
+
     .setting-button {
       background: none;
       border: none;
@@ -35,38 +37,35 @@
         border-radius: 20px;
       }
     }
+
     .dropdown-menu {
+      position: absolute; /* 드롭다운 메뉴 위치를 설정 버튼 기준으로 조정 */
+      top: 60px; /* 설정 버튼 아래에 위치 */
+      right: 0; /* 설정 버튼과 우측 맞춤 */
       background-color: #fff; /* 흰색 배경 */
-      border: 1px solid #ddd; /* 경계선 */
+      border: 2px solid #ddd; /* 경계선 */
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15); /* 그림자 효과 */
-      border-radius: 8px; /* 모서리 둥글게 */
       overflow: hidden; /* 내부 요소가 넘치지 않도록 */
       z-index: 1000; /* 다른 요소 위에 표시 */
       min-width: 150px; /* 최소 너비 설정 */
       display: flex;
       flex-direction: column; /* 세로 정렬 */
-      .dropdown-item {
-        padding: 10px 15px; /* 내부 여백 설정 */
-        cursor: pointer; /* 클릭 가능하게 커서 변경 */
-        font-size: 16px; /* 폰트 크기 */
-        color: #333; /* 텍스트 색상 */
-        background-color: #fff; /* 배경 흰색 */
-        border-bottom: 1px solid #ddd; /* 항목 사이에 경계선 추가 */
-        
-        &:hover {
-          background-color: #f2f2f2; /* 마우스 오버 시 배경 색상 변경 */
-        }
-    
-        &:last-child {
-          border-bottom: none; /* 마지막 항목의 경계선 제거 */
-        }
+    }
+
+    .dropdown-item {
+      padding: 10px 15px; /* 내부 여백 설정 */
+      cursor: pointer; /* 클릭 가능하게 커서 변경 */
+      font-size: 16px; /* 폰트 크기 */
+      color: #333; /* 텍스트 색상 */
+      background-color: #fff; /* 배경 흰색 */
+      border-bottom: 1px solid #ddd; /* 항목 사이에 경계선 추가 */
+      
+      &:hover {
+        background-color: #f2f2f2; /* 마우스 오버 시 배경 색상 변경 */
       }
+
     }
   }
-
-  
-
-  
 
   .quiz-solve-page {
     display: flex;

--- a/yuquiz/src/styles/quiztype/MultipleChoose.scss
+++ b/yuquiz/src/styles/quiztype/MultipleChoose.scss
@@ -1,70 +1,80 @@
 .quiz-container {
-    width: 100vh;
-    text-align: center;
-    border: 2px solid silver;
+  width: 100vh;
+  text-align: center;
+  border: 2px solid silver;
+  border-radius: 8px;
+  padding: 50px;
+  
+  .gotolist-button {
+    margin-top: 10px;
+    border-radius: 6px;
+    width: 90px;
+    height: 30px;
+    &:hover {
+      background-color: silver;
+    }
+  }
+}
+
+.quiz-header {
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 20px;
+}
+
+.quiz-question {
+  margin-bottom: 20px;
+}
+
+.quiz-options {
+  display: flex;
+  justify-content: center; /* 중앙에 배치 */
+  flex-wrap: wrap; /* 선택지가 너무 많으면 줄바꿈 */
+  gap: 15px; /* 선택지 간격 */
+  margin-bottom: 20px;
+
+  .quiz-option {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+    border: 2px solid #ccc;
     border-radius: 8px;
-    padding: 50px;
-  }
-  
-  .quiz-header {
-    font-size: 24px;
-    font-weight: bold;
-    margin-bottom: 20px;
-  }
-  
-  .quiz-question {
-    margin-bottom: 20px;
-  }
-  
-  .quiz-options {
-    display: flex;
-    flex-direction: column; /* 세로 정렬 */
-    align-items: center; /* 중앙 정렬 */
-    margin-bottom: 20px;
-  
-    .quiz-option {
-      display: flex;
-      align-items: center;
-      justify-content: flex-start;
-      width: 100%;
-      padding: 10px;
-      border: 2px solid #ccc;
-      border-radius: 8px;
-      margin-bottom: 10px;
-      cursor: pointer;
-      transition: background-color 0.3s;
-  
-      &:hover {
-        background-color: #eee;
-      }
-  
-      input {
-        margin-right: 10px;
-      }
-  
-      label {
-        flex-grow: 1;
-        text-align: left;
-      }
+    cursor: pointer;
+    transition: background-color 0.3s;
+    flex: 1 1 200px; /* 최소 200px 크기로 가로로 배치 */
+    max-width: 200px; /* 최대 너비 설정 */
+
+    &:hover {
+      background-color: #eee;
+    }
+
+    input {
+      margin-right: 10px;
+    }
+
+    label {
+      flex-grow: 1;
+      text-align: left;
     }
   }
-  
-  .submit-box {
-    display: flex;
-    justify-content: flex-end;
-    width: 100%;
-  
-    .quiz-submit {
-      padding: 10px 20px;
-      cursor: pointer;
-      border-radius: 8px;
-      border: 1px solid black;
-      transition: background-color 0.3s;
-  
-      &:disabled {
-        cursor: not-allowed;
-        background-color: #ccc;
-      }
+}
+
+.submit-box {
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+
+  .quiz-submit {
+    padding: 10px 20px;
+    cursor: pointer;
+    border-radius: 8px;
+    border: 1px solid black;
+    transition: background-color 0.3s;
+
+    &:disabled {
+      cursor: not-allowed;
+      background-color: #ccc;
     }
   }
-  
+}

--- a/yuquiz/src/styles/quiztype/OXQuiz.scss
+++ b/yuquiz/src/styles/quiztype/OXQuiz.scss
@@ -4,6 +4,16 @@
     border: 2px solid silver;
     border-radius: 8px;
     padding: 50px;
+    .gotolist-button{
+      margin-top: 10px;
+      border-radius: 6px;
+      width: 90px;
+      height: 30px;
+      &:hover {
+        background-color: silver;
+      }
+    }
+    
   }
   
   .quiz-header {

--- a/yuquiz/src/styles/quiztype/ShortAnswer.scss
+++ b/yuquiz/src/styles/quiztype/ShortAnswer.scss
@@ -7,6 +7,15 @@
     text-align: center;
     border: 2px solid silver;
     border-radius: 8px;
+    .gotolist-button{
+      margin-top: 10px;
+      border-radius: 6px;
+      width: 90px;
+      height: 30px;
+      &:hover {
+        background-color: silver;
+      }
+    }
   }
   .quiz-header {
     font-size: 24px;


### PR DESCRIPTION
## 개요

퀴즈 리스트 페이지에서 퀴즈를 눌러서 들어가게 되는 퀴즈를 푸는 페이지 구현

## 구현 사항

- 퀴즈 유형에 맞는 컴포넌트 불러와서 퀴즈 풀 수 있게 함.
- 사용자가 작성한 퀴즈의 경우에는 수정하기 및 삭제를 보이도록 함
- 삭제 구현
- 수정 구현(수정은 기존 정보를 불러와서 거기서 고쳐서 제출하면 됨)
- getQuiz, deleteQuiz, fixQuiz 서비스 함수들로 api통신 원할하게 함

## 기타

- 추후에 isWriter, isPinned, isLiked 활용해서 좋아요 즐겨찾기 기능 구현하기
- 그리고 풀고 답 채점하는 것은 백과 확실히 논의해서 유형별로 어떻게 처리하는지 이해하고 로직 작성하기

## 이미지

1. 객관식 , 주관식, OX 문제 푸는 화면
![image](https://github.com/user-attachments/assets/80ab4ecf-00c6-49b7-873e-b33c6983c501)
![image](https://github.com/user-attachments/assets/bd75b2f6-8166-4570-b2ab-f8102d6c3060)
![image](https://github.com/user-attachments/assets/0d67fa78-7e8a-47cc-94b6-f7ae7dca1eeb)

2. 기능 드롭다운
2.1 본인이 작성자일 때
![image](https://github.com/user-attachments/assets/5595d297-9200-4bc3-935c-8aa4dbda6970)
2.2 본인이 작성자가 아닐 때
![image](https://github.com/user-attachments/assets/1936a834-159a-40fb-99de-0ad687e3d445)

3. 수정 ( 예전 pr과 ui는 동일하니 참고바람)
![image](https://github.com/user-attachments/assets/9e24ccb8-94e3-4ae8-be30-6c27964ba9cc)
