### PR TITLE
feat: 퀴즈 채점 및 정답처리 로직 구현

### DIFF
--- a/yuquiz/src/components/solveQuiz/MultipleChoose.jsx
+++ b/yuquiz/src/components/solveQuiz/MultipleChoose.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from "react";
 import { getQuiz } from "../../services/quiz/QuizManage";
+import { getGrade } from "../../services/quiz/QuizSolve"; // 서버와 통신하기 위해 추가
 import "../../styles/quiztype/MultipleChoose.scss";
 
 export const MultipleChoose = ({ quizID }) => {
   const [quizData, setQuizData] = useState(null);
-  const [selectedAnswers, setSelectedAnswers] = useState([]);
+  const [selectedAnswers, setSelectedAnswers] = useState([]); // 선택한 답의 인덱스를 저장하도록 변경
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const [isCorrect, setIsCorrect] = useState(null);
 
@@ -20,31 +21,38 @@ export const MultipleChoose = ({ quizID }) => {
     return <div>로딩 중...</div>;
   }
 
-  const handleAnswerClick = (answer) => {
+  const handleAnswerClick = (index) => {
+    // 선택된 답의 인덱스를 저장
     setSelectedAnswers((prevAnswers) =>
-      prevAnswers.includes(answer)
-        ? prevAnswers.filter((ans) => ans !== answer)
-        : [...prevAnswers, answer]
+      prevAnswers.includes(index)
+        ? prevAnswers.filter((ans) => ans !== index)
+        : [...prevAnswers, index]
     );
   };
 
-  const handleSubmit = () => {
-    if (
-      !quizData ||
-      !quizData.correctAnswer ||
-      !Array.isArray(quizData.correctAnswer)
-    ) {
-      console.error("correctAnswer가 정의되지 않았거나 배열이 아닙니다.");
+  const handleSubmit = async () => {
+    if (!quizData || !quizData.choices) {
+      console.error("퀴즈 데이터가 잘못되었습니다.");
       return;
     }
 
-    const correctAnswers = quizData.correctAnswer;
+    // 선택한 답을 인덱스 배열로 변환하여 하나의 문자열로 결합
+    // answerString은 선택된 인덱스에 +1을 더하여 문자열로 만듦
+    const answerString = selectedAnswers
+      .map((index) => index + 1) // 인덱스 + 1
+      .sort((a, b) => a - b) // 오름차순 정렬
+      .join(""); // 문자열로 결합
+    console.log(answerString); // 디버깅용
 
-    const isAllCorrect =
-      selectedAnswers.length === correctAnswers.length &&
-      selectedAnswers.every((answer) => correctAnswers.includes(answer));
+    try {
+      // 서버로 정답을 전송하여 채점
+      const result = await getGrade(quizID, { answer: answerString });
+      setIsCorrect(result ? "맞았습니다!" : "틀렸습니다.");
+    } catch (error) {
+      console.error("채점 중 오류 발생:", error);
+      setIsCorrect("서버 오류로 채점할 수 없습니다.");
+    }
 
-    setIsCorrect(isAllCorrect ? "맞았습니다!" : "틀렸습니다.");
     setHasSubmitted(true);
   };
 
@@ -72,8 +80,8 @@ export const MultipleChoose = ({ quizID }) => {
                   id={`choice-${index}`}
                   name="quiz-choice"
                   value={choice}
-                  checked={selectedAnswers.includes(choice)}
-                  onChange={() => handleAnswerClick(choice)}
+                  checked={selectedAnswers.includes(index)}
+                  onChange={() => handleAnswerClick(index)} // 인덱스를 저장
                 />
                 <label htmlFor={`choice-${index}`}>{choice}</label>
               </div>

--- a/yuquiz/src/components/solveQuiz/MultipleChoose.jsx
+++ b/yuquiz/src/components/solveQuiz/MultipleChoose.jsx
@@ -2,12 +2,14 @@ import React, { useState, useEffect } from "react";
 import { getQuiz } from "../../services/quiz/QuizManage";
 import { getGrade } from "../../services/quiz/QuizSolve"; // 서버와 통신하기 위해 추가
 import "../../styles/quiztype/MultipleChoose.scss";
+import { useNavigate } from "react-router-dom";
 
 export const MultipleChoose = ({ quizID }) => {
   const [quizData, setQuizData] = useState(null);
   const [selectedAnswers, setSelectedAnswers] = useState([]); // 선택한 답의 인덱스를 저장하도록 변경
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const [isCorrect, setIsCorrect] = useState(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchQuizData = async () => {
@@ -61,7 +63,12 @@ export const MultipleChoose = ({ quizID }) => {
       <div className="quiz-container">
         <h2>{quizData.title}</h2>
         <p>{isCorrect}</p>
-        <button className="gotolist-button">목록으로</button>
+        <button
+          className="gotolist-button"
+          onClick={() => navigate("/quiz/list")}
+        >
+          목록으로
+        </button>
       </div>
     );
   }

--- a/yuquiz/src/components/solveQuiz/MultipleChoose.jsx
+++ b/yuquiz/src/components/solveQuiz/MultipleChoose.jsx
@@ -47,7 +47,7 @@ export const MultipleChoose = ({ quizID }) => {
     try {
       // 서버로 정답을 전송하여 채점
       const result = await getGrade(quizID, { answer: answerString });
-      setIsCorrect(result ? "맞았습니다!" : "틀렸습니다.");
+      setIsCorrect(result ? "맞았습니다!🙆‍♂️" : "틀렸습니다.🙅‍♂️");
     } catch (error) {
       console.error("채점 중 오류 발생:", error);
       setIsCorrect("서버 오류로 채점할 수 없습니다.");

--- a/yuquiz/src/components/solveQuiz/OXQuiz.jsx
+++ b/yuquiz/src/components/solveQuiz/OXQuiz.jsx
@@ -1,15 +1,17 @@
 import React, { useState, useEffect } from "react";
 import { getQuiz } from "../../services/quiz/QuizManage";
+import { getAnswer, getGrade } from "../../services/quiz/QuizSolve"; // 서버와 통신하기 위해 추가
 import "../../styles/quiztype/OXQuiz.scss";
 
 export const OXQuiz = ({ quizID }) => {
   const [quizData, setQuizData] = useState(null);
-  const [selectedAnswer, setSelectedAnswer] = useState(null);
-  const [score, setScore] = useState(0);
-  const [hasSubmitted, setHasSubmitted] = useState(false);
-  const [IsCorrect, setIsCorrect] = useState("맞았습니다.");
+  const [selectedAnswer, setSelectedAnswer] = useState(null); // 선택된 답
+  const [score, setScore] = useState(0); // 점수
+  const [hasSubmitted, setHasSubmitted] = useState(false); // 제출 여부
+  const [isCorrect, setIsCorrect] = useState(""); // 정답 여부 메시지
 
   useEffect(() => {
+    // 퀴즈 데이터 가져오기
     const fetchQuizData = async () => {
       const data = await getQuiz(quizID);
       setQuizData(data);
@@ -28,24 +30,34 @@ export const OXQuiz = ({ quizID }) => {
   };
 
   // 제출 처리
-  const handleSubmit = () => {
-    if (selectedAnswer === quizData.choices[0]) {
-      setScore(1);
-    } else {
-      setScore(0);
+  const handleSubmit = async () => {
+    if (!selectedAnswer) {
+      alert("정답을 선택하세요.");
+      return;
     }
+
+    // 선택한 답을 "1" 또는 "0"으로 변환하여 서버로 제출
+    const answer = selectedAnswer === quizData.choices[0] ? "1" : "0";
+    console.log("정답은 이건데?", getAnswer(quizID));
+    try {
+      const result = await getGrade(quizID, { answer });
+      setIsCorrect(result ? "맞았습니다!🙆‍♂️" : "틀렸습니다.🙅‍♂️");
+    } catch (error) {
+      console.error("채점 중 오류 발생:", error);
+      setIsCorrect("서버 오류로 채점할 수 없습니다.");
+    }
+
+    // 숫자로 변환하여 점수 설정 (필요 시)
+    setScore(parseInt(answer, 10)); // "1" 또는 "0"을 숫자로 변환하여 설정
     setHasSubmitted(true); // 제출 후 버튼 비활성화
   };
 
   // 제출 후 메시지 처리
   if (hasSubmitted) {
-    if (score === 0) {
-      setIsCorrect("틀렸습니다.");
-    }
     return (
       <div className="quiz-container">
         <h2>퀴즈가 완료되었습니다!</h2>
-        <p>{IsCorrect}</p>
+        <p>{isCorrect}</p>
         <button className="gotolist-button">목록으로</button>
       </div>
     );
@@ -55,10 +67,20 @@ export const OXQuiz = ({ quizID }) => {
     <div className="quiz-container">
       <p className="quiz-question">{quizData.question}</p>
       <div className="quiz-options">
-        <button onClick={() => handleAnswerClick(quizData.choices[0])}>
+        <button
+          className={`quiz-option-button ${
+            selectedAnswer === quizData.choices[0] ? "selected" : ""
+          }`}
+          onClick={() => handleAnswerClick(quizData.choices[0])}
+        >
           O
         </button>
-        <button onClick={() => handleAnswerClick(quizData.choices[1])}>
+        <button
+          className={`quiz-option-button ${
+            selectedAnswer === quizData.choices[1] ? "selected" : ""
+          }`}
+          onClick={() => handleAnswerClick(quizData.choices[1])}
+        >
           X
         </button>
       </div>

--- a/yuquiz/src/components/solveQuiz/OXQuiz.jsx
+++ b/yuquiz/src/components/solveQuiz/OXQuiz.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { getQuiz } from "../../services/quiz/QuizManage";
 import { getAnswer, getGrade } from "../../services/quiz/QuizSolve"; // 서버와 통신하기 위해 추가
 import "../../styles/quiztype/OXQuiz.scss";
+import { useNavigate } from "react-router-dom";
 
 export const OXQuiz = ({ quizID }) => {
   const [quizData, setQuizData] = useState(null);
@@ -9,6 +10,8 @@ export const OXQuiz = ({ quizID }) => {
   const [score, setScore] = useState(0); // 점수
   const [hasSubmitted, setHasSubmitted] = useState(false); // 제출 여부
   const [isCorrect, setIsCorrect] = useState(""); // 정답 여부 메시지
+
+  const navigate = useNavigate();
 
   useEffect(() => {
     // 퀴즈 데이터 가져오기
@@ -58,7 +61,12 @@ export const OXQuiz = ({ quizID }) => {
       <div className="quiz-container">
         <h2>퀴즈가 완료되었습니다!</h2>
         <p>{isCorrect}</p>
-        <button className="gotolist-button">목록으로</button>
+        <button
+          className="gotolist-button"
+          onClick={() => navigate("/quiz/list")}
+        >
+          목록으로
+        </button>
       </div>
     );
   }

--- a/yuquiz/src/components/solveQuiz/ShortAnswer.jsx
+++ b/yuquiz/src/components/solveQuiz/ShortAnswer.jsx
@@ -1,17 +1,24 @@
 import React, { useState, useEffect } from "react";
 import { getQuiz } from "../../services/quiz/QuizManage";
 import "../../styles/quiztype/ShortAnswer.scss";
+import { useNavigate } from "react-router-dom";
+import { getGrade } from "../../services/quiz/QuizSolve";
 
 export const ShortAnswer = ({ quizID }) => {
   const [quizData, setQuizData] = useState(null);
   const [writtenAnswer, setWrittenAnswer] = useState("");
   const [hasSubmitted, setHasSubmitted] = useState(false);
   const [isCorrect, setIsCorrect] = useState(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchQuizData = async () => {
-      const data = await getQuiz(quizID);
-      setQuizData(data);
+      try {
+        const data = await getQuiz(quizID);
+        setQuizData(data);
+      } catch (error) {
+        console.error("퀴즈 데이터를 가져오는 중 오류가 발생했습니다:", error);
+      }
     };
     fetchQuizData();
   }, [quizID]);
@@ -24,9 +31,11 @@ export const ShortAnswer = ({ quizID }) => {
     setWrittenAnswer(e.target.value);
   };
 
-  const handleSubmit = () => {
-    const isAnswerCorrect = writtenAnswer === quizData.correctAnswer;
-    setIsCorrect(isAnswerCorrect ? "맞았습니다!" : "틀렸습니다.");
+  const handleSubmit = async () => {
+    const answer = writtenAnswer.toString(); // 문자열로 변환
+    const isAnswerCorrect = await getGrade(quizID, { answer });
+
+    setIsCorrect(isAnswerCorrect ? "맞았습니다! 🙆‍♂️" : "틀렸습니다. 🙅‍♂️");
     setHasSubmitted(true);
   };
 
@@ -35,7 +44,12 @@ export const ShortAnswer = ({ quizID }) => {
       <div className="quiz-container">
         <h2>{quizData.question}</h2>
         <p>{isCorrect}</p>
-        <button className="gotolist-button">목록으로</button>
+        <button
+          className="gotolist-button"
+          onClick={() => navigate("/quiz/list")}
+        >
+          목록으로
+        </button>
       </div>
     );
   }

--- a/yuquiz/src/pages/quiz/QuizCreator.jsx
+++ b/yuquiz/src/pages/quiz/QuizCreator.jsx
@@ -3,6 +3,7 @@ import { IoMdArrowBack } from "react-icons/io";
 import "../../styles/quiz/QuizCreator.scss";
 import { Link, useNavigate } from "react-router-dom";
 import { handlerSubmitQuiz } from "../../services/quiz/quizCreator";
+
 export const QuizCreator = () => {
   const [questionTitle, setQuestionTitle] = useState("");
   const [questionContent, setQuestionContent] = useState("");
@@ -34,7 +35,7 @@ export const QuizCreator = () => {
         { num: 2, text: "False", correct: false },
       ]);
     } else if (questionType === "SHORT_ANSWER") {
-      setAnswers([{ num: 1, text: "", correct: true }]); // 단답식은 하나의 정답만 존재
+      setAnswers([{ num: 1, text: "", correct: true }]); // 단답형에 하나의 정답 객체로 설정
     } else {
       setAnswers([
         { num: 1, text: "", correct: false },
@@ -47,37 +48,38 @@ export const QuizCreator = () => {
 
   const handleAnswerChange = (index, field, value) => {
     const newAnswers = [...answers];
-    newAnswers[index][field] = value;
+    if (questionType === "SHORT_ANSWER") {
+      newAnswers[0][field] = value; // 단답형은 항상 첫 번째 객체를 수정
+    } else {
+      newAnswers[index][field] = value; // 그 외의 유형에서는 해당 인덱스의 답변을 수정
+    }
     setAnswers(newAnswers);
   };
 
   const handleSubmitQuiz = () => {
-    // Multiple Choice: 정답 번호를 문자열로 저장
     let answer = "";
 
     if (questionType === "MULTIPLE_CHOICE") {
       const correctAnswers = answers
-        .filter((answer) => answer.correct) // correct가 true인 답안만 필터링
-        .map((answer) => answer.num) // 정답 번호 추출
-        .sort((a, b) => a - b); // 오름차순 정렬
-
-      answer = correctAnswers.join(""); // 번호를 문자열로 합침 (예: "13")
+        .filter((answer) => answer.correct)
+        .map((answer) => answer.num)
+        .sort((a, b) => a - b);
+      answer = correctAnswers.join(""); // 정답 번호를 문자열로 합침
     }
 
-    // True/False: 정답이 True면 "1", False면 "0"으로 저장
     if (questionType === "TRUE_FALSE") {
       const correctAnswer = answers.find((answer) => answer.correct);
       answer = correctAnswer && correctAnswer.text === "True" ? "1" : "0";
-      // correctAnswer가 존재하고, 그 값이 "True"일 때만 "1", 아니면 "0"으로 설정
     }
 
-    // Short Answer: 단답형은 단일 정답이므로 정답 번호는 "1"로 고정
     if (questionType === "SHORT_ANSWER") {
-      answer = "1";
+      answer = answers[0].text; // 단답형에서는 하나의 정답만 보내기 위해
     }
 
-    // 사용자가 입력한 답안 내용은 choices에 배열로 저장
-    const choices = answers.map((answer) => answer.text);
+    const choices =
+      questionType !== "SHORT_ANSWER"
+        ? answers.map((answer) => answer.text)
+        : []; // 단답형에서는 choices가 비어 있게 설정
 
     const data = {
       title: questionTitle,

--- a/yuquiz/src/pages/quiz/QuizCreator.jsx
+++ b/yuquiz/src/pages/quiz/QuizCreator.jsx
@@ -87,7 +87,7 @@ export const QuizCreator = () => {
       choices: choices,
       subjectId: 2,
     };
-
+    console.log(data);
     if (handlerSubmitQuiz(data)) {
       alert("퀴즈 생성 성공!");
       navigate("/");

--- a/yuquiz/src/pages/quiz/QuizCreator.jsx
+++ b/yuquiz/src/pages/quiz/QuizCreator.jsx
@@ -67,12 +67,13 @@ export const QuizCreator = () => {
     // True/False: 정답이 True면 "1", False면 "0"으로 저장
     if (questionType === "TRUE_FALSE") {
       const correctAnswer = answers.find((answer) => answer.correct);
-      answer = correctAnswer ? "1" : "0"; // True이면 "1", False이면 "0"
+      answer = correctAnswer && correctAnswer.text === "True" ? "1" : "0";
+      // correctAnswer가 존재하고, 그 값이 "True"일 때만 "1", 아니면 "0"으로 설정
     }
 
     // Short Answer: 단답형은 단일 정답이므로 정답 번호는 "1"로 고정
     if (questionType === "SHORT_ANSWER") {
-      answer = "1"; // 단답형의 경우 정답은 하나뿐이므로 "1"로 고정
+      answer = "1";
     }
 
     // 사용자가 입력한 답안 내용은 choices에 배열로 저장

--- a/yuquiz/src/services/quiz/QuizSolve.js
+++ b/yuquiz/src/services/quiz/QuizSolve.js
@@ -1,12 +1,13 @@
 import { HttpStatusCode } from "axios";
 import api from "../apiService";
 const SERVER_API = process.env.REACT_APP_YUQUIZ;
-
 const getGrade = async (quizId, answer) => {
   try {
     const res = await api.post(`${SERVER_API}/quizzes/${quizId}/grade`, answer);
-    if (res.code === HttpStatusCode.Accepted) {
-      return res.reponse;
+    console.log("getGrade 함수 리턴값임", res); // 객체를 문자열로 변환하지 않고 그대로 출력
+    if (res.status === HttpStatusCode.Ok || res.status === 200) {
+      // HttpStatusCode.Ok 또는 200 확인
+      return res.data.response; // res.data.response로 수정하여 올바른 데이터 접근
     }
   } catch (error) {
     if (error.response) {
@@ -16,6 +17,7 @@ const getGrade = async (quizId, answer) => {
     }
   }
 };
+
 const getAnswer = async (quizId) => {
   const params = {
     quizId: quizId,

--- a/yuquiz/src/services/quiz/QuizSolve.js
+++ b/yuquiz/src/services/quiz/QuizSolve.js
@@ -23,11 +23,11 @@ const getAnswer = async (quizId) => {
     quizId: quizId,
   };
   try {
-    const res = await api.get(`${SERVER_API}/quizzes/${quizId}/grade`, {
+    const res = await api.get(`${SERVER_API}/quizzes/${quizId}/answer`, {
       params,
     });
-    if (res.code === HttpStatusCode.Accepted) {
-      return res.reponse;
+    if (res.status === HttpStatusCode.Ok) {
+      return res.data.response;
     }
   } catch (error) {
     if (error.response) {

--- a/yuquiz/src/services/quiz/QuizSolve.js
+++ b/yuquiz/src/services/quiz/QuizSolve.js
@@ -5,7 +5,7 @@ const getGrade = async (quizId, answer) => {
   try {
     const res = await api.post(`${SERVER_API}/quizzes/${quizId}/grade`, answer);
     console.log("getGrade 함수 리턴값임", res); // 객체를 문자열로 변환하지 않고 그대로 출력
-    if (res.status === HttpStatusCode.Ok || res.status === 200) {
+    if (res.status === HttpStatusCode.Ok) {
       // HttpStatusCode.Ok 또는 200 확인
       return res.data.response; // res.data.response로 수정하여 올바른 데이터 접근
     }

--- a/yuquiz/src/services/quiz/QuizSolve.js
+++ b/yuquiz/src/services/quiz/QuizSolve.js
@@ -1,0 +1,38 @@
+import { HttpStatusCode } from "axios";
+import api from "../apiService";
+const SERVER_API = process.env.REACT_APP_YUQUIZ;
+
+const getGrade = async (quizId, answer) => {
+  try {
+    const res = await api.post(`${SERVER_API}/quizzes/${quizId}/grade`, answer);
+    if (res.code === HttpStatusCode.Accepted) {
+      return res.reponse;
+    }
+  } catch (error) {
+    if (error.response) {
+      throw new Error("퀴즈가 존재하지 않습니다.");
+    } else {
+      throw new Error("서버와 연결할 수 없습니다.");
+    }
+  }
+};
+const getAnswer = async (quizId) => {
+  const params = {
+    quizId: quizId,
+  };
+  try {
+    const res = await api.get(`${SERVER_API}/quizzes/${quizId}/grade`, {
+      params,
+    });
+    if (res.code === HttpStatusCode.Accepted) {
+      return res.reponse;
+    }
+  } catch (error) {
+    if (error.response) {
+      throw new Error("퀴즈가 존재하지 않습니다.");
+    } else {
+      throw new Error("서버와 연결할 수 없습니다.");
+    }
+  }
+};
+export { getGrade, getAnswer };


### PR DESCRIPTION
## 개요

객관식, 단답식, O/X 퀴즈 유형별로 채점 로직 적용

## 구현 사항

- 객관식의 경우에는 답이 여러 개가 있을 수 있어서 만약 1번, 3번이 모두 정답이라면 정렬후 띄어쓰기 없이 "13"으로 정답을 처리 해줌
- 단답식의 경우에는 기존 choice에 정답을 담고 answer는 1로 고정해두고 검사를 했었는데 서버 측에서의 채점 로직과 너무 동떨어져 있었고 정답 노출 위험성이 있어서 choice는 비우고 answer에 바로 넣고 굳이 쓸데없는 값은 넣지 않고 채점을 하도록 맞추는 사람이 쓴 값을 서버로 보내 채점을 하도록 함.
- OX 퀴즈는 true면 1, false면 0으로 처리해서 answer에 담고 클릭을 했을 때는 라디오 버튼을 통해 정답을 state로 저장해두었다가 submit할때 String으로 보내 채점하고 return 값을 통해 정답인지 아닌지 판단(이건 3유형 전부 동일)
-목록으로 버튼을 누르면 목록으로 이동하도록 로직도 추가하였음.

## 기타

다음 작업으로는 { 즐겨찾기, 좋아요, 신고하기 } 세 기능을 연결만 해주면 퀴즈파트는 끝이 날듯함.

## 이미지
직접 테스트 해보는 것을 추천
![image](https://github.com/user-attachments/assets/d4869222-8c43-4980-a5ff-3cb09085dc66)
![image](https://github.com/user-attachments/assets/87c63f3f-7c5a-4a7e-b4f4-34fca1f12660)
![image](https://github.com/user-attachments/assets/b3bf3690-97b9-470e-b507-9ccd0c57851d)
