### PR TITLE
chore: quiz 정답, 오답, 미응시 각각 모두 다르게 처리

### DIFF
--- a/yuquiz/src/components/quizlist/QuizListItem.jsx
+++ b/yuquiz/src/components/quizlist/QuizListItem.jsx
@@ -2,7 +2,6 @@
 import React from "react";
 import "../../styles/quiz_list_page/QuizListItem.scss";
 import { Link } from "react-router-dom";
-
 const QuizListItem = ({ quiz }) => {
   const {
     quizId,
@@ -39,14 +38,18 @@ const QuizListItem = ({ quiz }) => {
         <p className="quiz-type">{getQuizTypeLabel(quizType)}</p>{" "}
         {/* 퀴즈 유형 표시 */}
         <p className="quiz-type">{subject || "과목"}</p> {/* 퀴즈 과목 표시 */}
+        <p
+          className={`quiz-solved ${
+            isSolved === null ? "unsolved" : isSolved ? "correct" : "wrong"
+          }`}
+        >
+          {isSolved === null ? "" : isSolved ? "🙆‍♂️" : "🙅"}
+        </p>
       </div>
       <div className="quiz-info-container">
         <div className="quiz-stats">
           <p className="quiz-likes">👍 {likeCount}</p>
           <p className="quiz-views">조회수: {viewCount}</p>
-          <p className={`quiz-solved ${isSolved ? "solved" : "unsolved"}`}>
-            {isSolved ? "풀이 완료" : ""}
-          </p>
         </div>
         <div className="quiz-meta">
           <p className="quiz-author">작성자: {nickname}</p>

--- a/yuquiz/src/styles/quiz_list_page/QuizListItem.scss
+++ b/yuquiz/src/styles/quiz_list_page/QuizListItem.scss
@@ -64,11 +64,12 @@
     font-weight: bold;
   }
   
-  .solved {
-    color: green;
+  .correct {
+    color: blue;
+    font-weight: 500;
   }
   
-  .unsolved {
+  .wrong {
     color: red;
   }
   


### PR DESCRIPTION
## 개요

퀴즈를 맞췄는지, 틀렸는지, 안풀었는 지에 대해서 상태 표시를 수정함 

## 구현 사항

- 맞춘 문제일 경우 문제 제목 옆에 🙆‍♂️
- 틀린 문제라면 🙅‍♂️(주황색) 
- 안 푼 문제라면 아무것도 뜨지않음

## 기타

세세한 스타일 수정임.

## 이미지
![image](https://github.com/user-attachments/assets/6dc956a4-2598-4a05-826f-e33ca3347c91)
