### PR TITLE
feat: 사용자 비밀번호 재설정 구현

### DIFF
--- a/yuquiz/src/pages/login/Login.jsx
+++ b/yuquiz/src/pages/login/Login.jsx
@@ -113,7 +113,9 @@ export const Login = () => {
         <Link to="/register" className="button-others">
           회원가입
         </Link>
-        <button className="button-others">비밀번호 찾기</button>
+        <Link to="/resetPW" className="button-others">
+          비밀번호 재설정
+        </Link>
       </div>
     </div>
   );

--- a/yuquiz/src/pages/login/findpw/ReqResetPW.jsx
+++ b/yuquiz/src/pages/login/findpw/ReqResetPW.jsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { ResetPW } from "../../../services/user/resetPW";
+import { IoMdArrowBack } from "react-icons/io";
+import "../../../styles/register/Register.scss"; // 스타일 파일 유지
+
+const ReqResetPW = () => {
+  const [formData, setFormData] = useState({
+    username: "",
+    email: "",
+  });
+  const navigate = useNavigate();
+  // 입력값 변경 핸들러
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData({
+      ...formData,
+      [name]: value,
+    });
+  };
+
+  // 폼 제출 핸들러
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const result = await ResetPW(formData.username, formData.email);
+    if (result.success) {
+      alert(result.message);
+      navigate(-1);
+    } else {
+      alert(result.message);
+    }
+  };
+
+  return (
+    <div className="register-body">
+      <div className="register-container">
+        <Link to="/login" className="back-button">
+          <IoMdArrowBack />
+        </Link>
+        <div className="title-container">
+          <p className="logo">YU Quiz</p>
+        </div>
+        <form onSubmit={handleSubmit}>
+          <div>
+            <input
+              type="text"
+              name="username"
+              className="form"
+              placeholder="아이디"
+              value={formData.username}
+              onChange={handleChange}
+              required
+            />
+          </div>
+          <div>
+            <input
+              type="email"
+              name="email"
+              className="form"
+              placeholder="이메일"
+              value={formData.email}
+              onChange={handleChange}
+              required
+            />
+          </div>
+          <button
+            type="submit"
+            className="button-register-done"
+            onClick={handleSubmit}
+          >
+            비밀번호 재설정 메일 전송
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ReqResetPW;

--- a/yuquiz/src/pages/login/findpw/ReqResetPW.jsx
+++ b/yuquiz/src/pages/login/findpw/ReqResetPW.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { ResetPW } from "../../../services/user/resetPW";
+import { confirmResetPW } from "../../../services/user/resetPW";
 import { IoMdArrowBack } from "react-icons/io";
 import "../../../styles/register/Register.scss"; // 스타일 파일 유지
 
@@ -22,7 +22,7 @@ const ReqResetPW = () => {
   // 폼 제출 핸들러
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const result = await ResetPW(formData.username, formData.email);
+    const result = await confirmResetPW(formData.username, formData.email);
     if (result.success) {
       alert(result.message);
       navigate(-1);

--- a/yuquiz/src/pages/login/findpw/ResResetPW.jsx
+++ b/yuquiz/src/pages/login/findpw/ResResetPW.jsx
@@ -1,0 +1,100 @@
+import React, { useState } from "react";
+import { Link, useNavigate, useLocation } from "react-router-dom";
+import { IoMdArrowBack } from "react-icons/io";
+import "../../../styles/register/Register.scss"; // 스타일 파일 유지
+import { doResetPW } from "../../../services/user/resetPW";
+
+const ResResetPW = () => {
+  const location = useLocation(); // 현재 URL 가져오기
+  const queryParams = new URLSearchParams(location.search);
+  const code = queryParams.get("code"); // 쿼리 파라미터에서 code 추출
+
+  const [formData, setFormData] = useState({
+    username: "",
+    password: "",
+    confirmPassword: "", // 비밀번호 재확인 필드 추가
+  });
+  const navigate = useNavigate();
+
+  // 입력값 변경 핸들러
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData({
+      ...formData,
+      [name]: value,
+    });
+  };
+
+  // 폼 제출 핸들러
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    // 비밀번호와 비밀번호 재확인 일치 여부 확인
+    if (formData.password !== formData.confirmPassword) {
+      alert("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    // 비밀번호 재설정 API 호출
+    const result = await doResetPW(formData.username, formData.password, code);
+    if (result.success) {
+      alert(result.message);
+      navigate("/");
+    } else {
+      alert(result.message);
+    }
+  };
+
+  return (
+    <div className="register-body">
+      <div className="register-container">
+        <Link to="/login" className="back-button">
+          <IoMdArrowBack />
+        </Link>
+        <div className="title-container">
+          <p className="logo">YU Quiz</p>
+        </div>
+        <form onSubmit={handleSubmit}>
+          <div>
+            <input
+              type="text"
+              name="username"
+              className="form"
+              placeholder="아이디"
+              value={formData.username}
+              onChange={handleChange}
+              required
+            />
+          </div>
+          <div>
+            <input
+              type="password"
+              name="password"
+              className="form"
+              placeholder="비밀번호"
+              value={formData.password}
+              onChange={handleChange}
+              required
+            />
+          </div>
+          <div>
+            <input
+              type="password"
+              name="confirmPassword"
+              className="form"
+              placeholder="비밀번호 재확인"
+              value={formData.confirmPassword}
+              onChange={handleChange}
+              required
+            />
+          </div>
+          <button type="submit" className="button-register-done">
+            비밀번호 재설정
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ResResetPW;

--- a/yuquiz/src/routes/router.jsx
+++ b/yuquiz/src/routes/router.jsx
@@ -18,6 +18,7 @@ import KakaoLoginCallback from "../pages/login/social/kakaoLoginCallBack";
 import RegisterOauth from "../pages/register/RegisterOauth";
 import NaverLoginCallback from "../pages/login/social/naverLoginCallBack";
 import ReqResetPW from "../pages/login/findpw/ReqResetPW";
+import ResResetPW from "../pages/login/findpw/ResResetPW";
 
 const router = createBrowserRouter([
   {
@@ -132,6 +133,10 @@ const router = createBrowserRouter([
       {
         path: "login/oauth2/code/naver",
         element: <NaverLoginCallback />,
+      },
+      {
+        path: "resetPW/req",
+        element: <ResResetPW />,
       },
     ],
   },

--- a/yuquiz/src/routes/router.jsx
+++ b/yuquiz/src/routes/router.jsx
@@ -17,6 +17,7 @@ import PostView from "../pages/post/PostView";
 import KakaoLoginCallback from "../pages/login/social/kakaoLoginCallBack";
 import RegisterOauth from "../pages/register/RegisterOauth";
 import NaverLoginCallback from "../pages/login/social/naverLoginCallBack";
+import ReqResetPW from "../pages/login/findpw/ReqResetPW";
 
 const router = createBrowserRouter([
   {
@@ -34,6 +35,10 @@ const router = createBrowserRouter([
       {
         path: "login",
         element: <Login />,
+      },
+      {
+        path: "resetPW",
+        element: <ReqResetPW />,
       },
       {
         path: "register",

--- a/yuquiz/src/services/user/resetPW.js
+++ b/yuquiz/src/services/user/resetPW.js
@@ -1,12 +1,14 @@
-import { HttpStatusCode } from "axios";
-import api from "../apiService";
-
-export const ResetPW = async (username, email) => {
+import axios, { HttpStatusCode } from "axios";
+const SERVER_API = process.env.REACT_APP_YUQUIZ;
+const confirmResetPW = async (username, email) => {
   try {
-    const response = await api.post(`auth/reset-password/verify-user`, {
-      username,
-      email,
-    });
+    const response = await axios.post(
+      `${SERVER_API}/api/v1/auth/reset-password/verify-user`,
+      {
+        username,
+        email,
+      }
+    );
     if (response.status === HttpStatusCode.Ok) {
       return { success: true, message: "재설정 이메일 전송완료" };
     }
@@ -25,3 +27,37 @@ export const ResetPW = async (username, email) => {
     }
   }
 };
+
+const doResetPW = async (username, password, code) => {
+  try {
+    const response = await axios.post(
+      `${SERVER_API}/api/v1/auth/reset-password`,
+      {
+        username,
+        password,
+        code,
+      }
+    );
+    if (response.status === HttpStatusCode.Ok) {
+      return {
+        success: true,
+        message: "비밀번호 재설정 완료! 다시 로그인 해보세요!",
+      };
+    }
+  } catch (error) {
+    if (error.response && error.response.status === HttpStatusCode.BadRequest) {
+      return {
+        success: false,
+        message:
+          error.response.data.message || "입력하신 정보가 유효하지 않습니다.",
+      };
+    } else {
+      console.error("Error in resetPW:", error);
+      return {
+        success: false,
+        message: "서버에 문제가 발생했습니다. 나중에 다시 시도하세요.",
+      };
+    }
+  }
+};
+export { confirmResetPW, doResetPW };

--- a/yuquiz/src/services/user/resetPW.js
+++ b/yuquiz/src/services/user/resetPW.js
@@ -1,9 +1,10 @@
 import axios, { HttpStatusCode } from "axios";
+import api from "../apiService";
 const SERVER_API = process.env.REACT_APP_YUQUIZ;
 const confirmResetPW = async (username, email) => {
   try {
     const response = await axios.post(
-      `${SERVER_API}/api/v1/auth/reset-password/verify-user`,
+      `${SERVER_API}/auth/reset-password/verify-user`,
       {
         username,
         email,
@@ -30,14 +31,11 @@ const confirmResetPW = async (username, email) => {
 
 const doResetPW = async (username, password, code) => {
   try {
-    const response = await axios.post(
-      `${SERVER_API}/api/v1/auth/reset-password`,
-      {
-        username,
-        password,
-        code,
-      }
-    );
+    const response = await axios.post(`${SERVER_API}/auth/reset-password`, {
+      username,
+      password,
+      code,
+    });
     if (response.status === HttpStatusCode.Ok) {
       return {
         success: true,
@@ -45,7 +43,7 @@ const doResetPW = async (username, password, code) => {
       };
     }
   } catch (error) {
-    if (error.response && error.response.status === HttpStatusCode.BadRequest) {
+    if (error.response && error.response.status === HttpStatusCode) {
       return {
         success: false,
         message:

--- a/yuquiz/src/services/user/resetPW.js
+++ b/yuquiz/src/services/user/resetPW.js
@@ -1,0 +1,27 @@
+import { HttpStatusCode } from "axios";
+import api from "../apiService";
+
+export const ResetPW = async (username, email) => {
+  try {
+    const response = await api.post(`auth/reset-password/verify-user`, {
+      username,
+      email,
+    });
+    if (response.status === HttpStatusCode.Ok) {
+      return { success: true, message: "재설정 이메일 전송완료" };
+    }
+  } catch (error) {
+    if (error.response && error.response.status === HttpStatusCode.BadRequest) {
+      return {
+        success: false,
+        message: error.response.data.message || "정보를 정확히 입력해주세요.",
+      };
+    } else {
+      console.error("Error in resetPW:", error);
+      return {
+        success: false,
+        message: "서버에 문제가 발생했습니다. 나중에 다시 시도하세요.",
+      };
+    }
+  }
+};


### PR DESCRIPTION
## 개요

비밀번호를 잊어버린 사용자를 위한 비밀번호 재설정 기능을 추가하였습니다. 사용자는 이메일을 통해 비밀번호를 재설정할 수 있습니다.

## 구현 사항

- **비밀번호 재설정 페이지 라우팅**: `/resetPW` 경로로 비밀번호 재설정 페이지에 접근 가능하도록 구현.
- **비밀번호 재설정 페이지 UI**: 비밀번호 초기화 요청 및 실제 비밀번호 재설정 페이지 구현.
  - **비밀번호 초기화 요청 (`ReqResetPW.jsx`)**: 사용자가 이메일과 아이디를 입력하면, 서버에서 검증 후 이메일로 비밀번호 재설정 링크를 전송합니다.
  - **비밀번호 재설정 (`ResResetPW.jsx`)**: 이메일에서 받은 링크를 통해 접속한 후 새로운 비밀번호를 설정할 수 있습니다.
- **비밀번호 재설정 API 연동**: 서버와의 통신을 통해 비밀번호 재설정 로직을 구현.
  - **사용자 확인 및 이메일 전송 (`confirmResetPW`)**: 입력한 아이디와 이메일이 올바른지 확인하고, 성공 시 비밀번호 재설정 링크를 이메일로 전송합니다.
  - **비밀번호 재설정 (`doResetPW`)**: 사용자가 새 비밀번호를 입력하고 서버로 이를 전송하여 비밀번호를 재설정합니다.

## 기타

컴포넌트 구조는 다음과 같습니다:

- **Login.jsx**: 비밀번호 재설정 링크 추가.
- **ReqResetPW.jsx**: 사용자 확인 후 이메일로 재설정 링크를 전송하는 페이지.
- **ResResetPW.jsx**: 이메일을 통해 접속한 사용자가 새로운 비밀번호를 입력하는 페이지.
- **resetPW.js**: 비밀번호 재설정 API 호출 로직을 구현.

## 이미지
- 로그인 하단의 비밀번호 재설정 이동 버튼
![image](https://github.com/user-attachments/assets/5923a120-8039-44a2-95c0-b4d03cffce49)

- 재설정 페이지
![image](https://github.com/user-attachments/assets/59832555-6a70-4ba9-898d-15b00fae25cf)

- 메일 화면
![image](https://github.com/user-attachments/assets/5e4b0c46-d438-4d78-99da-8ebfecd90563)

- 비밀번호 재설정 화면
![image](https://github.com/user-attachments/assets/5282b98e-4372-4530-8021-e77f5c78bddc)
