### PR TITLE
refact: report 로직 리팩토링 + 서버측과 report option 통일

### DIFF
--- a/yuquiz/src/constants/report/reportType.js
+++ b/yuquiz/src/constants/report/reportType.js
@@ -1,0 +1,26 @@
+export const REPORT_TYPES = {
+  INAPPROPRIATE_CONTENT: {
+    value: "INAPPROPRIATE_CONTENT",
+    label: "부적절한 콘텐츠",
+  },
+  COPYRIGHT_VIOLATION: {
+    value: "COPYRIGHT_VIOLATION",
+    label: "저작권 침해",
+  },
+  FRAUDULENT_INFORMATION: {
+    value: "FRAUDULENT_INFORMATION",
+    label: "사기성 정보",
+  },
+  EXPLICIT_CONTENT: {
+    value: "EXPLICIT_CONTENT",
+    label: "음란물 및 부적절한 내용",
+  },
+  ISSUE_ERROR: {
+    value: "ISSUE_ERROR",
+    label: "문제 오류",
+  },
+  OTHER: {
+    value: "OTHER",
+    label: "기타",
+  },
+};

--- a/yuquiz/src/pages/quiz/QuizSolve.jsx
+++ b/yuquiz/src/pages/quiz/QuizSolve.jsx
@@ -84,13 +84,18 @@ export const QuizSolve = () => {
       setIsLiked(liked);
     }
   };
-
+  const handleReportMordalClose = () => {
+    setIsReportModalOpen(false);
+  };
   const handleReportSubmit = async () => {
-    const reason = reportReason === "기타" ? customReason : reportReason;
+    if (reportReason === "OTHER" && !customReason) {
+      alert("기타는 사유를 작성해주세요.");
+      return;
+    }
     await sendReport(
       {
-        reason: reason,
-        type: "REPORT",
+        reason: customReason,
+        type: reportReason,
       },
       quizId
     );
@@ -165,13 +170,22 @@ export const QuizSolve = () => {
         className="report-modal"
         overlayClassName="modal-overlay" /* 배경 어둡게 */
       >
-        <h2>🚨 신고하기</h2>
+        <div className="report-title-container">
+          <h2>🚨 신고하기</h2>
+          <button
+            className="report-quit-button"
+            onClick={handleReportMordalClose}
+          >
+            ❌
+          </button>
+        </div>
+        {/*INAPPROPRIATE_CONTENT, COPYRIGHT_VIOLATION, FRAUDULENT_INFORMATION, EXPLICIT_CONTENT, ISSUE_ERROR, OTHER*/}
         <div className="report-options">
           <label>
             <input
               type="radio"
-              value="부적절한 콘텐츠"
-              checked={reportReason === "부적절한 콘텐츠"}
+              value="INAPPROPRIATE_CONTENT"
+              checked={reportReason === "INAPPROPRIATE_CONTENT"}
               onChange={(e) => setReportReason(e.target.value)}
             />
             부적절한 콘텐츠
@@ -179,8 +193,8 @@ export const QuizSolve = () => {
           <label>
             <input
               type="radio"
-              value="저작권 침해"
-              checked={reportReason === "저작권 침해"}
+              value="COPYRIGHT_VIOLATION"
+              checked={reportReason === "COPYRIGHT_VIOLATION"}
               onChange={(e) => setReportReason(e.target.value)}
             />
             저작권 침해
@@ -188,8 +202,8 @@ export const QuizSolve = () => {
           <label>
             <input
               type="radio"
-              value="사기성 정보"
-              checked={reportReason === "사기성 정보"}
+              value="FRAUDULENT_INFORMATION"
+              checked={reportReason === "FRAUDULENT_INFORMATION"}
               onChange={(e) => setReportReason(e.target.value)}
             />
             사기성 정보
@@ -197,8 +211,8 @@ export const QuizSolve = () => {
           <label>
             <input
               type="radio"
-              value="음란물 및 부적절한 내용"
-              checked={reportReason === "음란물 및 부적절한 내용"}
+              value="EXPLICIT_CONTENT"
+              checked={reportReason === "EXPLICIT_CONTENT"}
               onChange={(e) => setReportReason(e.target.value)}
             />
             음란물 및 부적절한 내용
@@ -206,15 +220,24 @@ export const QuizSolve = () => {
           <label>
             <input
               type="radio"
-              value="기타"
-              checked={reportReason === "기타"}
+              value="ISSUE_ERROR"
+              checked={reportReason === "ISSUE_ERROR"}
+              onChange={(e) => setReportReason(e.target.value)}
+            />
+            문제 오류
+          </label>
+          <label>
+            <input
+              type="radio"
+              value="OTHER"
+              checked={reportReason === "OTHER"}
               onChange={(e) => setReportReason(e.target.value)}
             />
             기타
           </label>
-          {reportReason === "기타" && (
+          {reportReason && (
             <textarea
-              placeholder="기타 신고 사유를 입력하세요"
+              placeholder="신고 사유를 입력해주세요!! (기타는 필수)"
               value={customReason}
               onChange={(e) => setCustomReason(e.target.value)}
               className="custom-reason-input"

--- a/yuquiz/src/pages/quiz/QuizSolve.jsx
+++ b/yuquiz/src/pages/quiz/QuizSolve.jsx
@@ -91,6 +91,9 @@ export const QuizSolve = () => {
     if (reportReason === "OTHER" && !customReason) {
       alert("기타는 사유를 작성해주세요.");
       return;
+    } else if (!reportReason) {
+      alert("신고 유형은 필수 입력입니다.");
+      return;
     }
     await sendReport(
       {

--- a/yuquiz/src/pages/quiz/QuizSolve.jsx
+++ b/yuquiz/src/pages/quiz/QuizSolve.jsx
@@ -14,6 +14,10 @@ import { ShortAnswer } from "../../components/solveQuiz/ShortAnswer";
 import { IoMdArrowBack } from "react-icons/io";
 import { IoEllipsisVertical } from "react-icons/io5";
 import Modal from "react-modal";
+import { REPORT_TYPES } from "../../constants/report/reportType";
+
+// 신고 유형 상수 분리 및 표시 문자열 포함
+const reportType = REPORT_TYPES;
 
 export const QuizSolve = () => {
   const { quizId } = useParams();
@@ -84,11 +88,13 @@ export const QuizSolve = () => {
       setIsLiked(liked);
     }
   };
+
   const handleReportMordalClose = () => {
     setIsReportModalOpen(false);
   };
+
   const handleReportSubmit = async () => {
-    if (reportReason === "OTHER" && !customReason) {
+    if (reportReason === reportType.OTHER.value && !customReason) {
       alert("기타는 사유를 작성해주세요.");
       return;
     } else if (!reportReason) {
@@ -182,62 +188,19 @@ export const QuizSolve = () => {
             ❌
           </button>
         </div>
-        {/*INAPPROPRIATE_CONTENT, COPYRIGHT_VIOLATION, FRAUDULENT_INFORMATION, EXPLICIT_CONTENT, ISSUE_ERROR, OTHER*/}
+
         <div className="report-options">
-          <label>
-            <input
-              type="radio"
-              value="INAPPROPRIATE_CONTENT"
-              checked={reportReason === "INAPPROPRIATE_CONTENT"}
-              onChange={(e) => setReportReason(e.target.value)}
-            />
-            부적절한 콘텐츠
-          </label>
-          <label>
-            <input
-              type="radio"
-              value="COPYRIGHT_VIOLATION"
-              checked={reportReason === "COPYRIGHT_VIOLATION"}
-              onChange={(e) => setReportReason(e.target.value)}
-            />
-            저작권 침해
-          </label>
-          <label>
-            <input
-              type="radio"
-              value="FRAUDULENT_INFORMATION"
-              checked={reportReason === "FRAUDULENT_INFORMATION"}
-              onChange={(e) => setReportReason(e.target.value)}
-            />
-            사기성 정보
-          </label>
-          <label>
-            <input
-              type="radio"
-              value="EXPLICIT_CONTENT"
-              checked={reportReason === "EXPLICIT_CONTENT"}
-              onChange={(e) => setReportReason(e.target.value)}
-            />
-            음란물 및 부적절한 내용
-          </label>
-          <label>
-            <input
-              type="radio"
-              value="ISSUE_ERROR"
-              checked={reportReason === "ISSUE_ERROR"}
-              onChange={(e) => setReportReason(e.target.value)}
-            />
-            문제 오류
-          </label>
-          <label>
-            <input
-              type="radio"
-              value="OTHER"
-              checked={reportReason === "OTHER"}
-              onChange={(e) => setReportReason(e.target.value)}
-            />
-            기타
-          </label>
+          {Object.values(reportType).map((type) => (
+            <label key={type.value}>
+              <input
+                type="radio"
+                value={type.value}
+                checked={reportReason === type.value}
+                onChange={(e) => setReportReason(e.target.value)}
+              />
+              {type.label}
+            </label>
+          ))}
           {reportReason && (
             <textarea
               placeholder="신고 사유를 입력해주세요!! (기타는 필수)"

--- a/yuquiz/src/services/quiz/QuizManage.js
+++ b/yuquiz/src/services/quiz/QuizManage.js
@@ -134,6 +134,9 @@ const sendReport = async (data, quizID) => {
       `${SERVER_API}/quizzes/${quizID}/report`,
       data
     );
+    if (response) {
+      alert("신고 성공!");
+    }
     return response;
   } catch (error) {
     if (error.response) {

--- a/yuquiz/src/services/quiz/QuizManage.js
+++ b/yuquiz/src/services/quiz/QuizManage.js
@@ -139,10 +139,10 @@ const sendReport = async (data, quizID) => {
     }
     return response;
   } catch (error) {
-    if (error.response) {
-      throw new Error("신고 과정 중 문제가 발생했습니다. 다시 시도해주세요.");
+    if (error.response.status === HttpStatusCode.Conflict) {
+      alert(error.response.message || "이미 신고한 퀴즈입니다.");
     } else {
-      throw new Error("서버와 연결할 수 없습니다.");
+      alert("존재하지 않는 퀴즈거나 서버와 연결할 수 없습니다.");
     }
   }
 };

--- a/yuquiz/src/styles/quiz/QuizSolve.scss
+++ b/yuquiz/src/styles/quiz/QuizSolve.scss
@@ -126,6 +126,16 @@
   top: 50%;
   transform: translateY(-50%);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  .report-title-container{
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    .report-quit-button{
+      border: none;
+      background-color: transparent;
+      size: 10px;
+    }
+  }
 }
 
 /* 신고 내용 입력 칸 */


### PR DESCRIPTION
## 개요

이번 PR은 퀴즈 신고 모달의 로직을 개선하고, 신고 처리 과정에서 사용자 경험을 향상시키기 위한 수정 사항을 포함하고 있습니다. 신고 사유의 value를 서버 측과 동일한 상수형 값으로 변경하고, 신고 성공 시 사용자에게 알림을 주는 기능을 추가했습니다. !! 또한, 신고 처리 중 발생할 수 있는 다양한 오류에 대한 처리를 강화했습니다.

## 구현 사항

### 1. **신고 모달 로직 수정**
   - 기존 신고 사유가 단순히 텍스트 값으로 처리되던 것을 상수형 value(`INAPPROPRIATE_CONTENT`, `COPYRIGHT_VIOLATION`, `FRAUDULENT_INFORMATION`, `EXPLICIT_CONTENT`, `ISSUE_ERROR`, `OTHER`)로 수정하였습니다. 
   - 이로써 신고 사유에 대한 명확한 식별이 가능해졌고, 추후 유지보수 및 확장성에도 도움이 됩니다.
   - 모달 내 ‘기타’ 사유를 선택한 경우 사용자에게 커스텀 사유를 입력하지 않으면 경고 메시지를 표시하여 필수 입력을 유도하는 기능을 추가했습니다.

### 2. **신고 성공 시 사용자 피드백 추가**
   - 신고가 성공적으로 처리되었을 때 사용자에게 alert을 통해 성공 메시지를 전달하도록 하였습니다. 
   - 이를 통해 사용자는 신고가 정상적으로 완료되었는지 즉각적으로 확인할 수 있어, 사용자 경험이 향상되었습니다.

### 3. **에러 처리 로직 개선**
   - **중복 신고 방지**: 이미 신고된 퀴즈에 대해 다시 신고하려고 할 경우 `HttpStatusCode.Conflict`를 감지하여 "이미 신고한 퀴즈입니다."라는 메시지를 alert으로 보여줍니다.
   - **서버 연결 오류 처리**: 서버와의 연결이 불안정하거나 존재하지 않는 퀴즈에 대한 신고 시 적절한 에러 메시지를 alert으로 전달하여 사용자에게 문제를 인지시킵니다.
   - 이를 통해 사용자에게 혼란을 줄 수 있는 상황들을 미연에 방지하고, 더 나은 에러 핸들링 경험을 제공하게 되었습니다.

### 4. **스타일 수정**
   - 신고 모달에서 타이틀 컨테이너와 닫기 버튼의 스타일을 수정했습니다. 
   - 타이틀과 닫기 버튼을 좌우로 배치하여 레이아웃을 개선했고, 닫기 버튼의 크기와 스타일을 조정하여 더 직관적이고 일관된 사용자 인터페이스를 제공했습니다.

## 기타

- 신고 사유가 "기타"일 경우, 필수로 내용을 작성하게 하여 신고 이유의 완성도를 높였습니다.
- 코드에서 중복된 부분을 제거하여 가독성과 유지보수성을 높였습니다. 
- 불필요한 alert 메시지를 최소화하고, 상황에 맞는 피드백만을 제공하여 더 나은 사용자 경험을 추구했습니다.

## 이로 인해 개선된 점

- **유지보수성 향상**: 사유 value를 상수형으로 처리하여 향후 새로운 신고 유형이 추가되거나 수정될 때 더 쉽게 확장할 수 있습니다.
- **사용자 경험 개선**: 신고 성공 여부와 입력값 오류에 대한 명확한 피드백을 제공함으로써 사용자가 신고 과정에서 겪는 혼란을 최소화하였습니다.
- **안정성 강화**: 중복 신고 및 서버 연결 문제에 대한 에러 처리가 강화되어 예외 상황에서도 프로그램의 안정성이 높아졌습니다.
- **UI 개선**: 스타일 변경을 통해 시각적 일관성을 높이고, 신고 모달의 사용성을 향상시켰습니다.

## 이미지
- 신고 모달이 처음 열렸을 때
![image](https://github.com/user-attachments/assets/cbb7cd7c-dbab-4a54-b4c4-05d6d64d4eca)

- 신고 사유를 클릭했을 때 추가 입력창이 뜨게 됨
![image](https://github.com/user-attachments/assets/55746a79-8e93-4825-8339-4a42c66a0176)

- 신고 사유가 기타인데 사유를 적지 않았을 때
![image](https://github.com/user-attachments/assets/cc792a9b-17bc-410c-97f0-6eab21365278)

- 동일 퀴즈에 대해 중복신고를 진행 시
![image](https://github.com/user-attachments/assets/7296e780-4df0-4fd9-9b63-1fa003e44d8d)
